### PR TITLE
Fix expected snapshot path in readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -285,7 +285,7 @@ container before restoring a snapshot::
     buttervolume restore <snapshot>
 
 ``<snapshot>`` is the name of the snapshot, not the full path. It is expected
-to live in ``/var/lib/docker/snapshots``.
+to live in ``/var/lib/buttervolume/snapshots``.
 
 By default, the volume name corresponds to the volume the snapshot was created
 from. But you can optionally restore the snapshot to a different volume name by
@@ -333,7 +333,7 @@ consuming a lot of bandwith or disk space::
     buttervolume send <host> <snapshot>
 
 ``<snapshot>`` is the name of the snapshot, not the full path. It is expected
-to live in ``/var/lib/docker/snapshots`` and is replicated to the same path on
+to live in ``/var/lib/buttervolume/snapshots`` and is replicated to the same path on
 the remote host.
 
 

--- a/README.rst
+++ b/README.rst
@@ -254,7 +254,7 @@ You can create a readonly snapshot of the volume with::
     buttervolume snapshot <volume>
 
 The volumes are currently expected to live in ``/var/lib/buttervolume/volumes`` and
-the snapshot will be created in ``/var/lib/docker/snapshots``, by appending the
+the snapshot will be created in ``/var/lib/buttervolume/snapshots``, by appending the
 datetime to the name of the volume, separated with ``@``.
 
 
@@ -317,7 +317,7 @@ You can delete a snapshot with::
     buttervolume rm <snapshot>
 
 ``<snapshot>`` is the name of the snapshot, not the full path. It is expected
-to live in ``/var/lib/docker/snapshots``.
+to live in ``/var/lib/buttervolume/snapshots``.
 
 
 Replicate a snapshot to another host
@@ -529,8 +529,8 @@ Stop docker, create required mount point and restart docker::
 
     systemctl stop docker
     mkdir -p /var/lib/buttervolume/volumes
-    mkdir -p /var/lib/docker/snapshots
-    mkdir -p /var/lib/docker/received
+    mkdir -p /var/lib/buttervolume/snapshots
+    mkdir -p /var/lib/buttervolume/received
     mount -o loop,subvol=volumes /var/lib/docker/btrfs.img /var/lib/buttervolume/volumes
     mount -o loop,subvol=snapshots /var/lib/docker/btrfs.img /var/lib/buttervolume/snapshots
     mount -o loop,subvol=received /var/lib/docker/btrfs.img /var/lib/buttervolume/received
@@ -542,8 +542,8 @@ find back your previous docker volumes::
 
     systemctl stop docker
     umount /var/lib/buttervolume/volumes
-    umount /var/lib/docker/snapshots
-    umount /var/lib/docker/received
+    umount /var/lib/buttervolume/snapshots
+    umount /var/lib/buttervolume/received
     systemctl start docker
     rm /var/lib/docker/btrfs.img
 


### PR DESCRIPTION
The default snapshot path was change in 3.0.0, I think.

This PR updates all the references in the readme file to the new location.