### PR TITLE
Make it easy to enable copy-on-write for new docker volumes

### DIFF
--- a/buttervolume/plugin.py
+++ b/buttervolume/plugin.py
@@ -81,7 +81,10 @@ def volume_create(req):
     if name in [v['Name']for v in list_volumes()['Volumes']]:
         return {'Err': ''}
     try:
-        btrfs.Subvolume(volpath).create()
+        if 'copyonwrite' in name:
+            btrfs.Subvolume(volpath).create(cow=True)
+        else:
+            btrfs.Subvolume(volpath).create()
     except CalledProcessError as e:
         return {'Err': e.stderr.decode()}
     except OSError as e:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,7 +17,7 @@ RUN set -x; \
     && mkdir /etc/buttervolume /root/.ssh
 
 ENV VERSION master
-RUN curl -o buttervolume.zip -SL https://github.com/anybox/buttervolume/archive/${VERSION}.zip \
+RUN curl -o buttervolume.zip -SL https://github.com/tyculus/buttervolume/archive/${VERSION}.zip \
     && unzip buttervolume.zip \
     && rm buttervolume.zip \
     && mv buttervolume-${VERSION} buttervolume \


### PR DESCRIPTION
_Make it easy to enable copy-on-write for new docker volumes by putting 'copyonwrite' into the volume's name. It can be anywhere within the string, but a good example would be as a '\_copyonwrite' suffix._

Hey, I just found out about your plugin and I really like it so far. In your code I saw that you already have a "cow=False" flag (within btrfs.py) for enabling/disabling copy-on-write behaviour during volume creation, but it is unused. I made a quick change that allows for explicitly enabling cow for new volumes by adding 'copyonwrite' to the name of the volume. It's not too short to be in a volume name by chance. I thought about using 'cow', but that may accidentally happen to be a substring in somebody's volume name.

I am new to docker plugins and this might not be the 'right' way to add this feature, but it surely is the easiest way. What do you think?

tyculus