### PR TITLE
SSH_PORT as plugin env variable

### DIFF
--- a/docker/config.json
+++ b/docker/config.json
@@ -26,5 +26,15 @@
     },
     "Linux": {
         "Capabilities": ["CAP_SYS_ADMIN"]
-    }
+    },
+    "Env": [
+        {
+            "Name": "SSH_PORT",
+            "Description": "SSH Port",
+            "Settable": [
+                "value"
+            ],
+            "Value": "1122"
+        }
+    ]
 }


### PR DESCRIPTION
This should fix #40 

I was not able to test the change, building the plugin failed for seemingly unrelated reasonse (can't find python webtest package).

Hoping to get the ball rolling with this PR