### PR TITLE
Bump rootfs docker base image to debian buster.

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stretch
+FROM debian:buster
 MAINTAINER Christophe Combelles. <ccomb@anybox.fr>
 
 RUN set -x; \


### PR DESCRIPTION
Pip cannot find webtest anymore on debian:stretch
This version bump allows to build the rootfs docker image again without additional changes.

Also mentioned here: #41 