### PR TITLE
Fix Multi-Architecture Support for ARM64/Raspberry Pi (fix #34)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,8 +50,17 @@ ENV PYTHONPATH=/usr/local/lib/python3.11/site-packages
 
 # add tini to avoid sshd zombie processes
 ENV TINI_VERSION=v0.19.0
-ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
-RUN chmod +x /tini
+RUN set -eux; \
+    dpkgArch="$(dpkg --print-architecture)"; \
+    case "${dpkgArch##*-}" in \
+        amd64) tiniArch='amd64' ;; \
+        arm64) tiniArch='arm64' ;; \
+        armhf) tiniArch='armhf' ;; \
+        i386) tiniArch='i386' ;; \
+        *) echo >&2 "unsupported architecture: ${dpkgArch}"; exit 1 ;; \
+    esac; \
+    curl -fsSL "https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-${tiniArch}" -o /tini; \
+    chmod +x /tini
 
 COPY entrypoint.sh /
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
#  :wrench: Problem

  The Docker plugin fails on ARM64 systems (like Raspberry Pi 4) with "exec format error" because Tini binary is hardcoded to x86_64 architecture, causing the issue reported in #34.

#  :cake: Solution

  Added automatic architecture detection for Tini binary download:
  - Detects container architecture using dpkg --print-architecture
  - Downloads correct Tini binary for amd64, arm64, armhf, and i386
  - Fails gracefully with clear error for unsupported architectures

#  :rotating_light: Points to watch/comments

  All other components (Debian packages, Python dependencies, uv installer) are already architecture-neutral, so this should fully resolve ARM compatibility issues.

#  :desert_island: How to test

  - Build plugin on ARM64 system (Raspberry Pi 4): ./build.sh and please open another issue if any