### PR TITLE
Write down the rules an agent must follow in this repository

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,17 @@
+## :wrench: Problem
+
+> _Describe the problem you're trying to solve, the reason why you are creating this pull request._
+
+## :cake: Solution
+
+> _Explain the solution that this PR implements to solve the problem above._
+
+
+## :rotating_light:  Points to watch/comments
+
+> _If there is anything unusual or some clarifications needed for the reviewer to better understand the PR, discuss it here._
+
+## :desert_island: How to test
+
+> _What someone else than you should do to validate that the solution you implemented is working as expected. Don't hesitate to be too verbose and to explain in details, using bullet points for example, the steps to follow to test the expected behavior._
+

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ rootfs
 __pycache__/
 *.db
 *.log
+.claude/worktrees/

--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,11 @@ sandbox*
 .eggs/
 docker/rootfs/
 venv/
+.venv/
 buttervolume.zip
 rootfs
+.pytest_cache/
+.ruff_cache/
+__pycache__/
+*.db
+*.log

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,70 @@
+# AGENTS.md
+
+Buttervolume is a Docker Volume Plugin that manages Docker volumes as BTRFS
+subvolumes: snapshot, restore, clone, replicate. Python, Bottle, argparse.
+
+## Finding your way around
+
+- `README.rst` is the user manual: install, CLI usage, configuration, volume
+  migration. Never duplicate it here; fix it there when it is wrong.
+- `buttervolume/plugin.py`: the Docker Volume Plugin HTTP API. Every endpoint is
+  one `@app.route("/VolumeDriver.*")` in `setup_routes`, and that function is the
+  authoritative route list.
+- `buttervolume/btrfs.py`: the only place that shells out to `btrfs`.
+- `buttervolume/cli.py`: the argparse commands, the scheduler thread and the
+  Bottle application the plugin serves on its unix socket.
+- `test.py`: the whole test suite, driven through `webtest` against the app.
+- `CHANGES.rst`: the changelog, one entry per user-visible change.
+
+## Commands
+
+```bash
+uv venv && uv sync --extra dev
+./test_local.sh [test_name]   # tests against a local BTRFS dir, no Docker
+./test.sh [VERSION]           # tests the built plugin in Docker
+./build.sh [VERSION]          # build the Docker plugin
+sudo .venv/bin/buttervolume run
+uv run ruff check . && uv run ruff format .
+```
+
+## Engineering rules
+
+- **No silent success, no silent failure.** Never a fallback value, an empty
+  list or an optimistic log when a step failed. Raise a `ButtervolumeError`
+  subclass (or `BtrfsError` in `btrfs.py`) and let it reach the caller. A wrong
+  answer is worse than a clear error, because the caller cannot tell.
+- **A snapshot only exists the day it was restored.** Any change to the
+  snapshot, send or restore paths must be proven by a test that restores.
+- **Destruction stays deliberate.** Nothing deletes a volume or a snapshot on
+  its own initiative; only an explicit command or the purge pattern the user
+  asked for.
+- **Fix the root cause, at the shared function.** Before editing a handler,
+  check its siblings: one guard in a helper beats a guard in every caller.
+- **Pure inside, effects at the edges.** Pattern parsing, name validation and
+  state transitions are pure functions, testable without a filesystem. Shelling
+  out and writing files happen at the boundary.
+- **Validate at the trust boundary.** Volume and snapshot names come from
+  Docker or from a remote host, and they end up in a path and in a shell
+  command. `validate_volume_name` is where that is decided, not the caller.
+- **The right level of tooling.** A volume plugin is managed with the standard
+  library, Bottle and BTRFS. Every added dependency is one more thing that can
+  lie; check the standard library first.
+- **Simplicity: perfection is when nothing is left to remove.** Most complexity
+  is accidental. Minimize mutable state, separate state from computation.
+- Nothing is committed that does not compile and pass `test_local.sh`.
+
+## Commits and pull requests
+
+- Every change goes through a pull request, on a branch starting from `master`.
+  Never commit to `master` directly, and never open a pull request from a
+  long-lived work branch that carries unrelated commits.
+- One pull request, one subject. If the description needs the word "and", it is
+  two pull requests.
+- Atomic commits: one subject each. Writing "and also" in a message means the
+  commit must be split.
+- The message explains why, in plain sentences, not what the diff already
+  shows. No em dashes.
+- `git add` names its files; never `git add -A`.
+- Re-read this file and `README.rst` before an important commit, and correct
+  them as soon as a sentence contradicts the code. Adding an endpoint or a
+  command that follows the conventions is not a reason to grow a list here.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,11 +8,14 @@ subvolumes: snapshot, restore, clone, replicate. Python, Bottle, argparse.
 - `README.rst` is the user manual: install, CLI usage, configuration, volume
   migration. Never duplicate it here; fix it there when it is wrong.
 - `buttervolume/plugin.py`: the Docker Volume Plugin HTTP API. Every endpoint is
-  one `@app.route("/VolumeDriver.*")` in `setup_routes`, and that function is the
-  authoritative route list.
-- `buttervolume/btrfs.py`: the only place that shells out to `btrfs`.
-- `buttervolume/cli.py`: the argparse commands, the scheduler thread and the
-  Bottle application the plugin serves on its unix socket.
+  a module-level `@route(...)` decorator there, and that list of decorators is
+  the authoritative route list.
+- `buttervolume/btrfs.py`: the subvolume operations, and `run_safe`, the guarded
+  way to call the `btrfs` command. One path escapes it and needs the same care:
+  `run_btrfs_send_receive` in `plugin.py` builds its own send and receive to
+  pipe them over SSH.
+- `buttervolume/cli.py`: the argparse commands, the scheduler thread, and the
+  waitress server that answers Docker on the unix socket.
 - `test.py`: the whole test suite, driven through `webtest` against the app.
 - `CHANGES.rst`: the changelog, one entry per user-visible change.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
## :wrench: Problem

Part of the work on this repository is now done by AI agents, and we are moving to a pull request workflow. The conventions we follow were nowhere written down, so every session started from scratch and the same mistakes came back: a fallback value hiding a failed btrfs call, a commit bundling three subjects, a branch opened from another work branch.

The `CLAUDE.md` that was being used was not those rules either. It was a copy of the user manual (CLI usage, plugin install, volume migration), 192 lines of it, re-read and paid for in tokens at the start of every session, and already drifting from `README.rst`. It was never committed, so this pull request adds files rather than replacing them: anyone holding an untracked `CLAUDE.md` or `PR_template.md` must delete their copy before pulling, or the merge will refuse to overwrite it.

## :cake: Solution

`AGENTS.md`, 70 lines, holds three things:

- where to look before touching anything, and which file is authoritative for what
- the handful of commands that build and test this project
- the rules themselves, each one coming from how this plugin actually fails: no silent success or silent failure, a snapshot only exists the day it was restored, destruction stays deliberate, validation happens at the trust boundary, and the standard library comes before a new dependency

It stays deliberately short. Everything the user needs stays in `README.rst` and is not repeated.

`CLAUDE.md` is a single line, `@AGENTS.md`, so one file serves every agent. The pull request template lands in `.github/pull_request_template.md`, where GitHub proposes it on its own instead of waiting to be found. `.gitignore` gains the leftovers a development session produces: `.venv/`, `.pytest_cache/`, `.ruff_cache/`, `__pycache__/`, `*.db`, `*.log`.

## :rotating_light: Points to watch/comments

The rules are written to be strict, since that is the point. Two of them deserve a look before they start being enforced:

- "Nothing is committed that does not compile and pass `test_local.sh`". Nothing enforces it yet. A CI run of `ruff` and the test suite would, and can come in a later pull request.
- "Every change goes through a pull request, on a branch starting from `master`". The `cluster` branch predates this rule and does not follow it. Its work will need to be split into subjects before it can be proposed.

This pull request changes no code at all.

## :desert_island: How to test

- Read `AGENTS.md` end to end and say where it is wrong, too vague, or missing a rule you actually care about.
- Check that every file it names exists and that the description matches: `README.rst`, `buttervolume/plugin.py`, `buttervolume/btrfs.py`, `buttervolume/cli.py`, `test.py`, `CHANGES.rst`.
- Open a test pull request on this repository and confirm GitHub fills the description with the template.
