### PR TITLE
Format the code the way ruff formats it

### DIFF
--- a/buttervolume/cli.py
+++ b/buttervolume/cli.py
@@ -385,9 +385,7 @@ def runjobs(config=SCHEDULE, test=False, schedule_log=None, timer=TIMER):
                     schedule_log[action][name] = now
                 if action.startswith("replicate:"):
                     if name in ReplicationInProgress:
-                        log.warning(
-                            f"Replication of {name} already in progress, skipping."
-                        )
+                        log.warning(f"Replication of {name} already in progress, skipping.")
                         continue
                     _, host = action.split(":")
                     log.info("Starting scheduled replication of %s", name)

--- a/buttervolume/plugin.py
+++ b/buttervolume/plugin.py
@@ -452,13 +452,15 @@ def snapshot_send(req):
     remote_snapshots = SNAPSHOTS_PATH if not test else TEST_REMOTE_PATH
 
     # take the latest snapshot suffixed with the target host
-    sent_snapshots = sorted([
-        s
-        for s in os.listdir(SNAPSHOTS_PATH)
-        if len(s.split("@")) == 3
-        and s.split("@")[0] == snapshot_name.split("@")[0]
-        and s.split("@")[2] == remote_host
-    ])
+    sent_snapshots = sorted(
+        [
+            s
+            for s in os.listdir(SNAPSHOTS_PATH)
+            if len(s.split("@")) == 3
+            and s.split("@")[0] == snapshot_name.split("@")[0]
+            and s.split("@")[2] == remote_host
+        ]
+    )
     latest = sent_snapshots[-1] if len(sent_snapshots) > 0 else None
     if latest and len(latest.rsplit("@")) == 3:
         latest = latest.rsplit("@", 1)[0]

--- a/test.py
+++ b/test.py
@@ -4,11 +4,11 @@ import os
 import shutil
 import subprocess
 import tempfile
+import threading
 import time
 import unittest
 import uuid
 import weakref
-import threading
 from contextlib import suppress
 from datetime import datetime, timedelta
 from os.path import join
@@ -438,9 +438,9 @@ class TestCase(unittest.TestCase):
         # check we have two snapshots
         self.assertEqual(
             2,
-            len({
-                s for s in os.listdir(SNAPSHOTS_PATH) if s.startswith(name) or s.startswith(name2)
-            }),
+            len(
+                {s for s in os.listdir(SNAPSHOTS_PATH) if s.startswith(name) or s.startswith(name2)}
+            ),
         )
         # unschedule
         self.app.post(
@@ -460,9 +460,9 @@ class TestCase(unittest.TestCase):
         runjobs(SCHEDULE, test=True, schedule_log=schedule_log)
         self.assertEqual(
             3,
-            len({
-                s for s in os.listdir(SNAPSHOTS_PATH) if s.startswith(name) or s.startswith(name2)
-            }),
+            len(
+                {s for s in os.listdir(SNAPSHOTS_PATH) if s.startswith(name) or s.startswith(name2)}
+            ),
         )
         # unschedule the last job
         self.app.post(
@@ -509,15 +509,19 @@ class TestCase(unittest.TestCase):
         runjobs(SCHEDULE, test=True, schedule_log=schedule_log)
         self.assertEqual(
             2,
-            len({
-                s for s in os.listdir(SNAPSHOTS_PATH) if s.startswith(name) or s.startswith(name)
-            }),
+            len(
+                {s for s in os.listdir(SNAPSHOTS_PATH) if s.startswith(name) or s.startswith(name)}
+            ),
         )
         self.assertEqual(
             1,
-            len({
-                s for s in os.listdir(TEST_REMOTE_PATH) if s.startswith(name) or s.startswith(name)
-            }),
+            len(
+                {
+                    s
+                    for s in os.listdir(TEST_REMOTE_PATH)
+                    if s.startswith(name) or s.startswith(name)
+                }
+            ),
         )
         # unschedule the last job
         self.app.post(
@@ -799,11 +803,13 @@ class TestCase(unittest.TestCase):
                 f.write("test sync")
             self.app.post(
                 "/VolumeDriver.Volume.Sync",
-                json.dumps({
-                    "Volumes": [name],
-                    "Hosts": ["localhost"],
-                    "Test": True,
-                }),
+                json.dumps(
+                    {
+                        "Volumes": [name],
+                        "Hosts": ["localhost"],
+                        "Test": True,
+                    }
+                ),
             )
             with open(join(path, "foobar")) as x:
                 self.assertEqual(x.read(), "test sync")
@@ -812,11 +818,13 @@ class TestCase(unittest.TestCase):
                 f.write("foobar")
             self.app.post(
                 "/VolumeDriver.Volume.Sync",
-                json.dumps({
-                    "Volumes": [name],
-                    "Hosts": ["localhost"],
-                    "Test": True,
-                }),
+                json.dumps(
+                    {
+                        "Volumes": [name],
+                        "Hosts": ["localhost"],
+                        "Test": True,
+                    }
+                ),
             )
             with open(join(path, "foobar")) as x:
                 self.assertEqual(x.read(), "test sync")
@@ -842,11 +850,13 @@ class TestCase(unittest.TestCase):
         # responding we should synchronise other hosts
         self.app.post(
             "/VolumeDriver.Schedule",
-            json.dumps({
-                "Name": name,
-                "Action": "synchronize:localhost,wronghost.mlf",
-                "Timer": 120,
-            }),
+            json.dumps(
+                {
+                    "Name": name,
+                    "Action": "synchronize:localhost,wronghost.mlf",
+                    "Timer": 120,
+                }
+            ),
         )
         # also replicate a non existing volume
         self.app.post(
@@ -876,11 +886,13 @@ class TestCase(unittest.TestCase):
         )
         self.app.post(
             "/VolumeDriver.Schedule",
-            json.dumps({
-                "Name": name,
-                "Action": "synchronize:localhost,wronghost.mlf",
-                "Timer": 0,
-            }),
+            json.dumps(
+                {
+                    "Name": name,
+                    "Action": "synchronize:localhost,wronghost.mlf",
+                    "Timer": 0,
+                }
+            ),
         )
 
     def test_init_file(self):


### PR DESCRIPTION
## :wrench: Problem

`pyproject.toml` has configured `ruff` for a while, with a line length and a set of lint rules, but nothing ever ran it. The tree does not match its own settings: `ruff format --check` reports three files, and `ruff check` one unsorted import block in `test.py`.

That matters right now because the next pull request adds a CI that runs both. Turning a check on over a tree that fails it makes the first run red and the diff impossible to read.

## :cake: Solution

Run `ruff check --fix` and `ruff format`, nothing else. Fifty lines, all whitespace and import order:

- `test.py`: import block sorted, and the reformatting of a few long calls
- `buttervolume/cli.py`: one log call that fits on a single line
- `buttervolume/plugin.py`: one list comprehension re-indented inside its `sorted()`

## :rotating_light: Points to watch/comments

No behavior changes, and no line was edited by hand. The reformatting touches lines the `cluster` branch also modifies, so that branch will have a small rebase to do; it is far cheaper now than after another few hundred lines of drift.

## :desert_island: How to test

- `uv run ruff check .` and `uv run ruff format --check .` both come back clean.
- The suite passes: `BUTTERVOLUME_TEST_DIR=$PWD/tmp/buttervolume_test ./test_local.sh` gives 16 passed, 4 skipped. The four skips need SSH, which is not available locally. Note the default `/tmp` is a tmpfs on many machines, hence the explicit BTRFS directory.
- `git diff master... --stat` shows only the three files above.