### PR TITLE
Run the linter and the tests on every pull request

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+      - run: uv run --extra dev ruff check .
+      - run: uv run --extra dev ruff format --check .
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+
+      # The tests create and snapshot BTRFS subvolumes, so they need a real
+      # BTRFS filesystem. A loop-mounted image gives them one, and the runner
+      # is thrown away afterwards.
+      - name: Mount a BTRFS filesystem for the tests
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y btrfs-progs
+          truncate -s 2G "$RUNNER_TEMP/btrfs.img"
+          mkfs.btrfs -q "$RUNNER_TEMP/btrfs.img"
+          sudo mkdir -p /mnt/btrfs
+          sudo mount -o loop "$RUNNER_TEMP/btrfs.img" /mnt/btrfs
+          sudo chown "$(id -un)" /mnt/btrfs
+
+      - run: ./test_local.sh
+        env:
+          BUTTERVOLUME_TEST_DIR: /mnt/btrfs/test

--- a/buttervolume/cli.py
+++ b/buttervolume/cli.py
@@ -385,9 +385,7 @@ def runjobs(config=SCHEDULE, test=False, schedule_log=None, timer=TIMER):
                     schedule_log[action][name] = now
                 if action.startswith("replicate:"):
                     if name in ReplicationInProgress:
-                        log.warning(
-                            f"Replication of {name} already in progress, skipping."
-                        )
+                        log.warning(f"Replication of {name} already in progress, skipping.")
                         continue
                     _, host = action.split(":")
                     log.info("Starting scheduled replication of %s", name)

--- a/buttervolume/plugin.py
+++ b/buttervolume/plugin.py
@@ -452,13 +452,15 @@ def snapshot_send(req):
     remote_snapshots = SNAPSHOTS_PATH if not test else TEST_REMOTE_PATH
 
     # take the latest snapshot suffixed with the target host
-    sent_snapshots = sorted([
-        s
-        for s in os.listdir(SNAPSHOTS_PATH)
-        if len(s.split("@")) == 3
-        and s.split("@")[0] == snapshot_name.split("@")[0]
-        and s.split("@")[2] == remote_host
-    ])
+    sent_snapshots = sorted(
+        [
+            s
+            for s in os.listdir(SNAPSHOTS_PATH)
+            if len(s.split("@")) == 3
+            and s.split("@")[0] == snapshot_name.split("@")[0]
+            and s.split("@")[2] == remote_host
+        ]
+    )
     latest = sent_snapshots[-1] if len(sent_snapshots) > 0 else None
     if latest and len(latest.rsplit("@")) == 3:
         latest = latest.rsplit("@", 1)[0]

--- a/test.py
+++ b/test.py
@@ -4,11 +4,11 @@ import os
 import shutil
 import subprocess
 import tempfile
+import threading
 import time
 import unittest
 import uuid
 import weakref
-import threading
 from contextlib import suppress
 from datetime import datetime, timedelta
 from os.path import join
@@ -438,9 +438,9 @@ class TestCase(unittest.TestCase):
         # check we have two snapshots
         self.assertEqual(
             2,
-            len({
-                s for s in os.listdir(SNAPSHOTS_PATH) if s.startswith(name) or s.startswith(name2)
-            }),
+            len(
+                {s for s in os.listdir(SNAPSHOTS_PATH) if s.startswith(name) or s.startswith(name2)}
+            ),
         )
         # unschedule
         self.app.post(
@@ -460,9 +460,9 @@ class TestCase(unittest.TestCase):
         runjobs(SCHEDULE, test=True, schedule_log=schedule_log)
         self.assertEqual(
             3,
-            len({
-                s for s in os.listdir(SNAPSHOTS_PATH) if s.startswith(name) or s.startswith(name2)
-            }),
+            len(
+                {s for s in os.listdir(SNAPSHOTS_PATH) if s.startswith(name) or s.startswith(name2)}
+            ),
         )
         # unschedule the last job
         self.app.post(
@@ -509,15 +509,19 @@ class TestCase(unittest.TestCase):
         runjobs(SCHEDULE, test=True, schedule_log=schedule_log)
         self.assertEqual(
             2,
-            len({
-                s for s in os.listdir(SNAPSHOTS_PATH) if s.startswith(name) or s.startswith(name)
-            }),
+            len(
+                {s for s in os.listdir(SNAPSHOTS_PATH) if s.startswith(name) or s.startswith(name)}
+            ),
         )
         self.assertEqual(
             1,
-            len({
-                s for s in os.listdir(TEST_REMOTE_PATH) if s.startswith(name) or s.startswith(name)
-            }),
+            len(
+                {
+                    s
+                    for s in os.listdir(TEST_REMOTE_PATH)
+                    if s.startswith(name) or s.startswith(name)
+                }
+            ),
         )
         # unschedule the last job
         self.app.post(
@@ -799,11 +803,13 @@ class TestCase(unittest.TestCase):
                 f.write("test sync")
             self.app.post(
                 "/VolumeDriver.Volume.Sync",
-                json.dumps({
-                    "Volumes": [name],
-                    "Hosts": ["localhost"],
-                    "Test": True,
-                }),
+                json.dumps(
+                    {
+                        "Volumes": [name],
+                        "Hosts": ["localhost"],
+                        "Test": True,
+                    }
+                ),
             )
             with open(join(path, "foobar")) as x:
                 self.assertEqual(x.read(), "test sync")
@@ -812,11 +818,13 @@ class TestCase(unittest.TestCase):
                 f.write("foobar")
             self.app.post(
                 "/VolumeDriver.Volume.Sync",
-                json.dumps({
-                    "Volumes": [name],
-                    "Hosts": ["localhost"],
-                    "Test": True,
-                }),
+                json.dumps(
+                    {
+                        "Volumes": [name],
+                        "Hosts": ["localhost"],
+                        "Test": True,
+                    }
+                ),
             )
             with open(join(path, "foobar")) as x:
                 self.assertEqual(x.read(), "test sync")
@@ -842,11 +850,13 @@ class TestCase(unittest.TestCase):
         # responding we should synchronise other hosts
         self.app.post(
             "/VolumeDriver.Schedule",
-            json.dumps({
-                "Name": name,
-                "Action": "synchronize:localhost,wronghost.mlf",
-                "Timer": 120,
-            }),
+            json.dumps(
+                {
+                    "Name": name,
+                    "Action": "synchronize:localhost,wronghost.mlf",
+                    "Timer": 120,
+                }
+            ),
         )
         # also replicate a non existing volume
         self.app.post(
@@ -876,11 +886,13 @@ class TestCase(unittest.TestCase):
         )
         self.app.post(
             "/VolumeDriver.Schedule",
-            json.dumps({
-                "Name": name,
-                "Action": "synchronize:localhost,wronghost.mlf",
-                "Timer": 0,
-            }),
+            json.dumps(
+                {
+                    "Name": name,
+                    "Action": "synchronize:localhost,wronghost.mlf",
+                    "Timer": 0,
+                }
+            ),
         )
 
     def test_init_file(self):

--- a/test_local.sh
+++ b/test_local.sh
@@ -13,12 +13,15 @@ LOCAL_TEST_DIR="${BUTTERVOLUME_TEST_DIR:-/tmp/buttervolume_test}"
 cleanup_test_dir() {
     [ -d "$LOCAL_TEST_DIR" ] || return 0
     echo "Cleaning up test directory: $LOCAL_TEST_DIR"
-    for subvolume in "$LOCAL_TEST_DIR"/*/*; do
-        if [ -d "$subvolume" ]; then
-            sudo btrfs subvolume delete "$subvolume" > /dev/null 2>&1 || true
-        fi
-    done
-    sudo rm -rf "$LOCAL_TEST_DIR"
+    # -depth walks children before parents, which is the order nested
+    # subvolumes have to be deleted in. Directories that are not subvolumes
+    # simply refuse, and rm takes care of them below.
+    sudo find "$LOCAL_TEST_DIR" -mindepth 1 -depth -type d \
+        -exec btrfs subvolume delete {} \; > /dev/null 2>&1 || true
+    sudo rm -rf "$LOCAL_TEST_DIR"/volumes "$LOCAL_TEST_DIR"/snapshots "$LOCAL_TEST_DIR"/received
+    # Left alone when it is a mount point, which is what the help text above
+    # tells people to set up.
+    rmdir "$LOCAL_TEST_DIR" 2> /dev/null || true
 }
 
 cleanup_test_dir

--- a/test_local.sh
+++ b/test_local.sh
@@ -7,11 +7,21 @@ set -e
 # Create local test directories (adjust path as needed)
 LOCAL_TEST_DIR="${BUTTERVOLUME_TEST_DIR:-/tmp/buttervolume_test}"
 
-# Clean up any existing test directory completely
-if [ -d "$LOCAL_TEST_DIR" ]; then
-    echo "Cleaning up existing test directory..."
+# The tests leave BTRFS subvolumes behind, and rm cannot delete those: the
+# snapshots are read-only, and everything the tests made belongs to root.
+# Each one has to go through btrfs subvolume delete first.
+cleanup_test_dir() {
+    [ -d "$LOCAL_TEST_DIR" ] || return 0
+    echo "Cleaning up test directory: $LOCAL_TEST_DIR"
+    for subvolume in "$LOCAL_TEST_DIR"/*/*; do
+        if [ -d "$subvolume" ]; then
+            sudo btrfs subvolume delete "$subvolume" > /dev/null 2>&1 || true
+        fi
+    done
     sudo rm -rf "$LOCAL_TEST_DIR"
-fi
+}
+
+cleanup_test_dir
 
 mkdir -p "$LOCAL_TEST_DIR"/{volumes,snapshots,received}
 
@@ -59,6 +69,4 @@ else
     sudo -E .venv/bin/python -m pytest test.py -v
 fi
 
-# Cleanup
-echo "Cleaning up test directory: $LOCAL_TEST_DIR"
-rm -rf "$LOCAL_TEST_DIR"
+cleanup_test_dir


### PR DESCRIPTION
## :wrench: Problem

Nothing in this repository checks anything automatically. `AGENTS.md` now says that nothing is committed which does not compile and pass `test_local.sh`, and that rule is worth exactly what enforces it, which today is nothing.

The evidence that it matters is recent: the `cluster` branch carried a file that did not compile, three endpoints that raised `NameError` on their first line, and a plugin that broke every route of the Docker API. A linter run would have caught half of it in a second.

## :cake: Solution

One workflow, two jobs, on every pull request and every push to `master`.

**Lint** runs `ruff check` and `ruff format --check`. Both pass on the tree as of the pull request this one builds on.

**Test** runs `test_local.sh`. The interesting part is what the suite needs: it creates BTRFS subvolumes, snapshots them, and reads them back with `btrfs subvolume show`, which needs root even though `btrfs subvolume create` does not. So the job installs `btrfs-progs`, loop-mounts a 2 GB BTRFS image on `/mnt/btrfs`, and points `BUTTERVOLUME_TEST_DIR` at it. The runner is discarded afterwards, so nothing is left behind.

The first run caught something on its way: the tests passed and the job still failed, because `test_local.sh` ends on `rm -rf`, which cannot remove what the tests leave behind. The snapshots are read-only subvolumes and the volumes belong to root. Each one now goes through `btrfs subvolume delete` first, and the same cleanup runs before the tests, so an interrupted run no longer blocks the next one. The second run is green, both jobs.

## :rotating_light: Points to watch/comments

**This pull request is based on #71, not on `master`.** It has to be: the lint job is red on a tree that has never been formatted. Merge #71 first, and this one will retarget itself to `master`.

Two things deliberately left out:

- The Docker plugin build (`build.sh` and `test.sh`). It needs a privileged daemon and several minutes, and it is not what a pull request usually breaks. Worth adding later on a schedule rather than on every push.
- The runner warns that `actions/checkout@v4` and `astral-sh/setup-uv@v5` target Node.js 20 and are forced onto Node.js 24. Only a warning today, and worth a bump the next time this file is touched.
- `pyproject.toml` declares no `requires-python`, so every `uv run` prints a warning and rewrites `uv.lock` to `>=3.12`, while the classifiers still advertise Python 3.8. The lock file already requires 3.11. Someone should decide which is true, but that is a separate subject and it does not block this.

## :desert_island: How to test

- Read the workflow; the whole thing is 40 lines.
- The real check is the run this pull request triggers on itself, which is where the loop-mounted BTRFS filesystem is proven. If `btrfs-progs` or the loop mount misbehaves on the runner, the test job says so.
- Locally, the same two commands the lint job runs: `uv run --extra dev ruff check .` and `uv run --extra dev ruff format --check .`.
