### PR TITLE
Fix the cleanup of the snapshot left behind by a failed replication

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,8 @@ CHANGELOG
   of reaching the filesystem and the btrfs command. A ``DTFORMAT`` producing a
   name that this validation would reject is refused at snapshot time, instead
   of creating a snapshot no endpoint could name again.
+- Fixed the cleanup of the snapshot created for a failed scheduled replication:
+  it crashed instead of deleting the snapshot, leaving it behind.
 - Fixed the purge tests, which passed or failed depending on how long they took
   to run.
 - Fixed the tests: create a BTRFS filesystems in a loop device if there is no BTRFS during tests.

--- a/buttervolume/cli.py
+++ b/buttervolume/cli.py
@@ -308,10 +308,13 @@ def sync(args, test=False):
     return res
 
 
-def remove(args):
+def remove(args, test=False):
     urlpath = "/VolumeDriver.Snapshot.Remove"
     param = json.dumps({"Name": args.name[0]})
-    resp = Session().post((f"http+unix://{urllib.parse.quote_plus(USOCKET)}{urlpath}"), param)
+    if test:
+        resp = TestApp(app).post(urlpath, param)
+    else:
+        resp = Session().post(f"http+unix://{urllib.parse.quote_plus(USOCKET)}{urlpath}", param)
     res = get_from(resp, "")
     if res:
         print(res)
@@ -389,6 +392,7 @@ def runjobs(config=SCHEDULE, test=False, schedule_log=None, timer=TIMER):
                         continue
                     _, host = action.split(":")
                     log.info("Starting scheduled replication of %s", name)
+                    snap = None
                     try:
                         ReplicationInProgress.add(name)
                         snap = snapshot(Arg(name=[name]), test=test)

--- a/buttervolume/cli.py
+++ b/buttervolume/cli.py
@@ -315,10 +315,9 @@ def remove(args, test=False):
         resp = TestApp(app).post(urlpath, param)
     else:
         resp = Session().post(f"http+unix://{urllib.parse.quote_plus(USOCKET)}{urlpath}", param)
-    res = get_from(resp, "")
-    if res:
-        print(res)
-    return res
+    # the endpoint answers with an empty payload, so the only thing to report
+    # is whether the deletion happened: get_from already logged the error.
+    return get_from(resp, "") is not False
 
 
 def purge(args, test=False):
@@ -407,8 +406,13 @@ def runjobs(config=SCHEDULE, test=False, schedule_log=None, timer=TIMER):
                         log.warning("Replication failed: %s", e)
                         # remove snapshot that was created for the failed replication
                         if snap:
-                            remove(Arg(name=[snap]), test=test)
-                            log.info("Removed snapshot %s for failed replication", snap)
+                            if remove(Arg(name=[snap]), test=test):
+                                log.info("Removed snapshot %s for failed replication", snap)
+                            else:
+                                log.warning(
+                                    "Could not remove snapshot %s of the failed replication",
+                                    snap,
+                                )
                     finally:
                         ReplicationInProgress.remove(name)
                 if action.startswith("purge:"):

--- a/test.py
+++ b/test.py
@@ -229,6 +229,29 @@ class TestCase(unittest.TestCase):
         self.assertEqual([s for s in os.listdir(SNAPSHOTS_PATH) if s.startswith(name + "@")], [])
         self.app.post("/VolumeDriver.Remove", json.dumps({"Name": name}))
 
+    def test_replication_cleanup_on_failure(self):
+        """A failed replication deletes the snapshot it created for the occasion"""
+        name = PREFIX_TEST_VOLUME + uuid.uuid4().hex
+        self.create_a_volume_with_a_file(name)
+        self.app.post(
+            "/VolumeDriver.Schedule",
+            json.dumps({"Name": name, "Action": "replicate:localhost", "Timer": 1}),
+        )
+        with patch("buttervolume.cli.send") as mock_send:
+            mock_send.side_effect = Exception("replication failed")
+            runjobs(SCHEDULE, True)
+        mock_send.assert_called_once()
+        # the snapshot created for the failed replication was removed
+        snapshots = [s for s in os.listdir(SNAPSHOTS_PATH) if s.startswith(name + "@")]
+        self.assertEqual(snapshots, [])
+        # the lock was released
+        self.assertNotIn(name, cli.ReplicationInProgress)
+        # unschedule
+        self.app.post(
+            "/VolumeDriver.Schedule",
+            json.dumps({"Name": name, "Action": "replicate:localhost", "Timer": 0}),
+        )
+
     def create_a_volume_with_a_file(self, name):
         # create a volume with a file
         path = join(VOLUMES_PATH, name)


### PR DESCRIPTION
When a scheduled replication failed, the scheduler tried to delete the snapshot it had just created for the occasion, but that call passed a `test` keyword argument that `remove()` does not accept. The resulting `TypeError` was swallowed by the scheduler's generic error handler, so the snapshot stayed behind and the cleanup advertised since the locking change had silently never worked.

Two related weaknesses are fixed at the same place:

- `remove()` now accepts the same `test` parameter as the other job functions (`snapshot`, `send`, `sync`, `purge`), so it goes through the test application during tests instead of a nonexistent unix socket.
- The `snap` variable is reset before each replication attempt. Previously, if `snapshot()` itself raised, the cleanup could reference a snapshot name left over from a previous loop iteration and delete the wrong snapshot.

A new test drives the failure path through the scheduler: the replication fails, and the test asserts that the snapshot created for it is gone and the replication lock is released. The test fails on master and passes with this change. Full local suite: 17 passed, 4 skipped (the SSH replication tests, as usual locally).