### PR TITLE
Validate snapshot names at the trust boundary

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,7 +8,9 @@ CHANGELOG
   volume path interpolated in the command line.
 - Snapshot names received through the API are now validated like volume names:
   a name containing a path traversal or shell characters is rejected instead
-  of reaching the filesystem and the btrfs command.
+  of reaching the filesystem and the btrfs command. A ``DTFORMAT`` producing a
+  name that this validation would reject is refused at snapshot time, instead
+  of creating a snapshot no endpoint could name again.
 - Fixed the purge tests, which passed or failed depending on how long they took
   to run.
 - Fixed the tests: create a BTRFS filesystems in a loop device if there is no BTRFS during tests.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,9 @@ CHANGELOG
 
 - The chattr call enabling compression no longer goes through a shell with the
   volume path interpolated in the command line.
+- Snapshot names received through the API are now validated like volume names:
+  a name containing a path traversal or shell characters is rejected instead
+  of reaching the filesystem and the btrfs command.
 - Fixed the purge tests, which passed or failed depending on how long they took
   to run.
 - Fixed the tests: create a BTRFS filesystems in a loop device if there is no BTRFS during tests.

--- a/README.rst
+++ b/README.rst
@@ -294,7 +294,9 @@ You can configure the following variables:
     * ``RUNPATH``: the path of the docker run directory (/run/docker)
     * ``SOCKET``: the path of the unix socket where buttervolume listens
     * ``TIMER``: the number of seconds between two runs of the scheduler jobs
-    * ``DTFORMAT``: the format of the datetime in the logs
+    * ``DTFORMAT``: the format of the datetime in the logs and in the snapshot
+      names. As a snapshot name has to remain usable in a path and in a command,
+      the format may only produce letters, digits, dot, colon, underscore and dash
     * ``LOGLEVEL``: the Python log level (INFO, DEBUG, etc.)
 
 The configuration can be done in this order of priority:

--- a/buttervolume/plugin.py
+++ b/buttervolume/plugin.py
@@ -145,6 +145,30 @@ def validate_volume_name(name):
     return name
 
 
+def validate_snapshot_name(name):
+    """Validate a snapshot name: volume@timestamp, plus @host for sent snapshots.
+
+    Snapshot names come from Docker or from a remote host and end up in a
+    path and in a shell command, so they get the same care as volume names.
+    """
+    if not name:
+        raise ValidationError("Snapshot name cannot be empty")
+
+    if len(name) > 255:
+        raise ValidationError("Snapshot name too long")
+
+    parts = name.split("@")
+    if len(parts) not in (2, 3):
+        raise ValidationError("Invalid snapshot name format")
+
+    validate_volume_name(parts[0])
+    for part in parts[1:]:
+        if not part or not re.match(r"^[a-zA-Z0-9.:_-]+$", part):
+            raise ValidationError("Snapshot name contains invalid characters")
+
+    return name
+
+
 def validate_hostname(hostname):
     """Validate hostname for SSH operations"""
     if not hostname:
@@ -443,7 +467,7 @@ def snapshot_send(req):
 
     # Validate inputs
     try:
-        validate_volume_name(snapshot_name.split("@")[0])  # Validate base volume name
+        validate_snapshot_name(snapshot_name)
         validate_hostname(remote_host)
     except ValidationError as e:
         return {"Err": str(e)}
@@ -553,10 +577,7 @@ def snapshot_sublist(_, name=""):
 @safe_handler
 def snapshot_delete(req):
     name = req["Name"]
-
-    # Basic validation of snapshot name format
-    if "@" not in name:
-        raise ValidationError("Invalid snapshot name format")
+    validate_snapshot_name(name)
 
     path = join(SNAPSHOTS_PATH, name)
     if not os.path.exists(path):
@@ -652,6 +673,8 @@ def snapshot_restore(req):
         if not snapshots:
             raise SnapshotNotFoundError(f"No snapshots found for volume '{volume_name}'")
         snapshot_name = sorted(snapshots)[-1]
+    else:
+        validate_snapshot_name(snapshot_name)
 
     snapshot_path = join(SNAPSHOTS_PATH, snapshot_name)
     if not os.path.exists(snapshot_path):

--- a/buttervolume/plugin.py
+++ b/buttervolume/plugin.py
@@ -139,7 +139,7 @@ def validate_volume_name(name):
         raise ValidationError("Volume name too long")
 
     # Only allow alphanumeric, dash, underscore, dot
-    if not re.match(r"^[a-zA-Z0-9._-]+$", name):
+    if not re.fullmatch(r"[a-zA-Z0-9._-]+", name):
         raise ValidationError("Volume name contains invalid characters")
 
     return name
@@ -163,10 +163,20 @@ def validate_snapshot_name(name):
 
     validate_volume_name(parts[0])
     for part in parts[1:]:
-        if not part or not re.match(r"^[a-zA-Z0-9.:_-]+$", part):
+        if not part or not re.fullmatch(r"[a-zA-Z0-9.:_-]+", part):
             raise ValidationError("Snapshot name contains invalid characters")
 
     return name
+
+
+def new_snapshot_name(volume_name):
+    """Name a new snapshot of this volume, as the API will have to read it back.
+
+    DTFORMAT is configurable, so a format holding a space or a plus sign would
+    build a name the validation above rejects: the snapshot would exist and no
+    endpoint could name it again. Better to refuse to create it.
+    """
+    return validate_snapshot_name(f"{volume_name}@{datetime.now().strftime(DTFORMAT)}")
 
 
 def validate_hostname(hostname):
@@ -175,7 +185,7 @@ def validate_hostname(hostname):
         raise ValidationError("Hostname cannot be empty")
 
     # Basic hostname validation
-    if not re.match(r"^[a-zA-Z0-9.-]+$", hostname):
+    if not re.fullmatch(r"[a-zA-Z0-9.-]+", hostname):
         raise ValidationError("Invalid hostname format")
 
     if len(hostname) > 253:
@@ -544,7 +554,7 @@ def volume_snapshot(req):
     if not os.path.exists(path) or not btrfs.Subvolume(path).exists():
         raise VolumeNotFoundError(f"Volume '{name}': no such volume")
 
-    timestamped = f"{name}@{datetime.now().strftime(DTFORMAT)}"
+    timestamped = new_snapshot_name(name)
     snapshot_path = join(SNAPSHOTS_PATH, timestamped)
 
     btrfs.Subvolume(path).snapshot(snapshot_path, readonly=True)
@@ -693,8 +703,7 @@ def snapshot_restore(req):
 
     if volume.exists():
         # backup and delete
-        timestamp = datetime.now().strftime(DTFORMAT)
-        stamped_name = f"{target_name}@{timestamp}"
+        stamped_name = new_snapshot_name(target_name)
         stamped_path = join(SNAPSHOTS_PATH, stamped_name)
         volume.snapshot(stamped_path, readonly=True)
         res["VolumeBackup"] = stamped_name

--- a/test.py
+++ b/test.py
@@ -196,7 +196,15 @@ class TestCase(unittest.TestCase):
         self.assertTrue(resp["Err"])
         self.assertTrue(os.path.exists(join(VOLUMES_PATH, name)))
         # malformed names are rejected by the three endpoints taking a snapshot name
-        for bad in ("@", "foo@", "a@b@c@d", "foo@$(reboot)", "foo@back`tick"):
+        for bad in (
+            "@",
+            "foo@",
+            "a@b@c@d",
+            "foo@$(reboot)",
+            "foo@back`tick",
+            # a trailing newline splits the remote command line in two
+            "foo@2026-01-01T00:00:00.000000\n",
+        ):
             for urlpath, param in (
                 ("/VolumeDriver.Snapshot.Remove", {"Name": bad}),
                 ("/VolumeDriver.Snapshot.Send", {"Name": bad, "Host": "localhost"}),
@@ -206,6 +214,19 @@ class TestCase(unittest.TestCase):
                 self.assertTrue(resp["Err"], f"{urlpath} accepted {bad!r}")
         # cleanup
         self.app.post("/VolumeDriver.Snapshot.Remove", json.dumps({"Name": snap}))
+        self.app.post("/VolumeDriver.Remove", json.dumps({"Name": name}))
+
+    def test_snapshot_name_must_stay_readable(self):
+        """A DTFORMAT building a name the API cannot read back is refused"""
+        name = PREFIX_TEST_VOLUME + uuid.uuid4().hex
+        self.create_a_volume_with_a_file(name)
+        # a space in the timestamp would give a snapshot no endpoint can name
+        with patch("buttervolume.plugin.DTFORMAT", "%Y-%m-%d %H:%M:%S"):
+            resp = jsonloads(
+                self.app.post("/VolumeDriver.Snapshot", json.dumps({"Name": name})).body
+            )
+        self.assertTrue(resp["Err"])
+        self.assertEqual([s for s in os.listdir(SNAPSHOTS_PATH) if s.startswith(name + "@")], [])
         self.app.post("/VolumeDriver.Remove", json.dumps({"Name": name}))
 
     def create_a_volume_with_a_file(self, name):

--- a/test.py
+++ b/test.py
@@ -180,6 +180,34 @@ class TestCase(unittest.TestCase):
             json.dumps({"Name": name, "Action": "replicate:localhost", "Timer": 0}),
         )
 
+    def test_snapshot_names_are_validated(self):
+        """Snapshot names from the API cannot reach outside the snapshots directory"""
+        name = PREFIX_TEST_VOLUME + uuid.uuid4().hex
+        self.create_a_volume_with_a_file(name)
+        snap = jsonloads(self.app.post("/VolumeDriver.Snapshot", json.dumps({"Name": name})).body)[
+            "Snapshot"
+        ]
+        # a traversal through an existing snapshot resolves to the volume
+        # itself: it must be rejected, not deleted
+        evil = f"{snap}/../../volumes/{name}"
+        resp = jsonloads(
+            self.app.post("/VolumeDriver.Snapshot.Remove", json.dumps({"Name": evil})).body
+        )
+        self.assertTrue(resp["Err"])
+        self.assertTrue(os.path.exists(join(VOLUMES_PATH, name)))
+        # malformed names are rejected by the three endpoints taking a snapshot name
+        for bad in ("@", "foo@", "a@b@c@d", "foo@$(reboot)", "foo@back`tick"):
+            for urlpath, param in (
+                ("/VolumeDriver.Snapshot.Remove", {"Name": bad}),
+                ("/VolumeDriver.Snapshot.Send", {"Name": bad, "Host": "localhost"}),
+                ("/VolumeDriver.Snapshot.Restore", {"Name": bad}),
+            ):
+                resp = jsonloads(self.app.post(urlpath, json.dumps(param)).body)
+                self.assertTrue(resp["Err"], f"{urlpath} accepted {bad!r}")
+        # cleanup
+        self.app.post("/VolumeDriver.Snapshot.Remove", json.dumps({"Name": snap}))
+        self.app.post("/VolumeDriver.Remove", json.dumps({"Name": name}))
+
     def create_a_volume_with_a_file(self, name):
         # create a volume with a file
         path = join(VOLUMES_PATH, name)


### PR DESCRIPTION
Snapshot names come from Docker or from a remote host and end up in a path and in a shell command, exactly like volume names, but only volume names were validated:

- `/VolumeDriver.Snapshot.Remove` accepted any name containing an `@`. A name like `snap/../../volumes/myvolume` passed that check, resolved to the volume itself, and `btrfs subvolume delete` destroyed it. The new test demonstrates this on master.
- `/VolumeDriver.Snapshot.Restore` did not check the snapshot name at all.
- `/VolumeDriver.Snapshot.Send` checked only the volume part, while the full name also reaches the remote shell command that deletes a stale snapshot before a full send.

Following the rule that validation is decided in one place and not by each caller, a single `validate_snapshot_name` function now sits next to `validate_volume_name`: two or three `@`-separated parts, the first one a valid volume name, the others restricted to timestamp and hostname characters. The three endpoints go through it.

The new test proves that a traversal through an existing snapshot is rejected instead of deleting the volume it points to (it fails on master, where the volume is actually destroyed), and that malformed names are rejected by all three endpoints. Full local suite: 17 passed, 4 skipped (the SSH replication tests, as usual locally).