### PR TITLE
Enable compression without going through a shell

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ CHANGELOG
 3.13 (unreleased)
 *****************
 
+- The chattr call enabling compression no longer goes through a shell with the
+  volume path interpolated in the command line.
 - Fixed the purge tests, which passed or failed depending on how long they took
   to run.
 - Fixed the tests: create a BTRFS filesystems in a loop device if there is no BTRFS during tests.

--- a/buttervolume/plugin.py
+++ b/buttervolume/plugin.py
@@ -282,7 +282,7 @@ def volume_create(req):
     # Enable compression if requested
     if compression and compression != "false":
         try:
-            run(f'chattr +c "{volpath}"', shell=True, check=True)
+            btrfs.run_safe(["chattr", "+c", volpath], timeout=10)
             log.info(f"Enabled compression for volume {name}")
         except Exception as e:
             log.warning(f"Could not enable compression for volume {name}: {e}")


### PR DESCRIPTION
The `chattr +c` call that enables compression on a new volume was the only place in the codebase where a user-derived path was interpolated into a shell command line (`run(f'chattr +c \"{volpath}\"', shell=True)`). The subvolume creation a few lines above already calls `chattr +C` through `btrfs.run_safe` with an argument list and no shell, so the compression call now does the same, with the same 10 second timeout.

The volume name is validated before this point, so this closes a defense-in-depth gap rather than an open injection, but a shell has no business here in the first place. The behavior on failure is unchanged: a warning, and the volume creation still succeeds, as the existing compression test verifies. Full local suite: 16 passed, 4 skipped (the SSH replication tests, as usual locally).