### PR TITLE
Run every BTRFS command through a single guard

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,9 @@ CHANGELOG
 - Allow using volumes created with legacy plugin anybox/buttervolume (fix #52)
 - Fixed deletion of old sent snapshots
 - Added support for compression (fix #36)
+- A failing BTRFS command is now always reported the same way, naming the command
+  and keeping the original error. Deleting a subvolume no longer has a silent
+  failure mode.
 
 3.12 (2024-11-05)
 *****************

--- a/buttervolume/btrfs.py
+++ b/buttervolume/btrfs.py
@@ -41,6 +41,9 @@ def run_safe(cmd, timeout, error=BtrfsError):
         raise error(f"Command failed: {' '.join(cmd)}\nStderr: {stderr}") from e
     except TimeoutExpired as e:
         raise error(f"Command timed out after {timeout}s: {' '.join(cmd)}") from e
+    except OSError as e:
+        # The command could not even be started: missing binary, no permission
+        raise error(f"Command could not be run: {' '.join(cmd)}\n{e}") from e
 
 
 class Subvolume:

--- a/buttervolume/btrfs.py
+++ b/buttervolume/btrfs.py
@@ -1,87 +1,46 @@
 import contextlib
 import os
-from subprocess import PIPE, CalledProcessError, TimeoutExpired
+from subprocess import CalledProcessError, TimeoutExpired
 from subprocess import run as _run
 
+# How long each command may legitimately take, in seconds
+SHOW_TIMEOUT = 15
+SNAPSHOT_TIMEOUT = 120
+CREATE_TIMEOUT = 120
+DELETE_TIMEOUT = 300
+CHATTR_TIMEOUT = 10
+LABEL_TIMEOUT = 15
 
-# Custom exceptions for BTRFS operations
+
 class BtrfsError(Exception):
     """Base exception for BTRFS operations"""
-
-    pass
 
 
 class BtrfsSubvolumeError(BtrfsError):
     """Raised when BTRFS subvolume operations fail"""
 
-    pass
 
+def run_safe(cmd, timeout, error=BtrfsError):
+    """Run a command without a shell and turn any failure into a typed error.
 
-class BtrfsFilesystemError(BtrfsError):
-    """Raised when BTRFS filesystem operations fail"""
-
-    pass
-
-
-class InvalidPathError(BtrfsError):
-    """Raised when path validation fails"""
-
-    pass
-
-
-def btrfs_operation(error_type, error_msg, timeout=60):
-    """Decorator that runs BTRFS commands with timeout and converts exceptions to specific types."""
-
-    def decorator(func):
-        def wrapper(self, *args, **kwargs):
-            # Call the function to get the command
-            cmd_list = func(self, *args, **kwargs)
-
-            try:
-                return _run(
-                    cmd_list,
-                    shell=False,
-                    check=True,
-                    capture_output=True,
-                    timeout=timeout,
-                ).stdout.decode()
-            except CalledProcessError as e:
-                cmd_str = " ".join(cmd_list)
-                stderr_output = e.stderr.decode() if e.stderr else "No error output"
-                raise error_type(
-                    f"{error_msg}: BTRFS command failed: {cmd_str}\nStderr: {stderr_output}"
-                ) from None
-            except TimeoutExpired:
-                cmd_str = " ".join(cmd_list)
-                raise error_type(
-                    f"{error_msg}: BTRFS command timed out after {timeout}s: {cmd_str}"
-                ) from None
-            except Exception as e:
-                raise error_type(f"{error_msg} - unexpected error: {str(e)}") from None
-
-        return wrapper
-
-    return decorator
-
-
-def run_safe(cmd_list, check=True, stdout=PIPE, stderr=PIPE, timeout=60):
-    """Simple run_safe for basic operations without error type conversion"""
+    :param timeout: how long the command may run, in seconds. No default:
+                    every caller states the delay it expects.
+    :param error: the exception class raised on failure.
+    :return: the standard output, decoded
+    """
     try:
         return _run(
-            cmd_list,
+            cmd,
             shell=False,
-            check=check,
-            stdout=stdout,
-            stderr=stderr,
+            check=True,
+            capture_output=True,
             timeout=timeout,
         ).stdout.decode()
     except CalledProcessError as e:
-        cmd_str = " ".join(cmd_list)
-        stderr_output = e.stderr.decode() if e.stderr else "No error output"
-        raise BtrfsError(f"BTRFS command failed: {cmd_str}\nStderr: {stderr_output}") from None
-    except TimeoutExpired:
-        cmd_str = " ".join(cmd_list)
-        raise BtrfsError(f"BTRFS command timed out after {timeout}s: {cmd_str}") from None
+        stderr = e.stderr.decode() if e.stderr else "No error output"
+        raise error(f"Command failed: {' '.join(cmd)}\nStderr: {stderr}") from e
+    except TimeoutExpired as e:
+        raise error(f"Command timed out after {timeout}s: {' '.join(cmd)}") from e
 
 
 class Subvolume:
@@ -93,7 +52,11 @@ class Subvolume:
 
     def show(self):
         """Parse btrfs subvolume show output"""
-        raw = run_safe(["btrfs", "subvolume", "show", self.path], timeout=15)
+        raw = run_safe(
+            ["btrfs", "subvolume", "show", self.path],
+            timeout=SHOW_TIMEOUT,
+            error=BtrfsSubvolumeError,
+        )
         lines = raw.split("\n")
 
         if len(lines) < 13:
@@ -118,8 +81,6 @@ class Subvolume:
 
     def exists(self):
         """Check if this path is a valid BTRFS subvolume"""
-        if not os.path.exists(self.path):
-            return False
         if not os.path.isdir(self.path):
             return False
         try:
@@ -127,57 +88,38 @@ class Subvolume:
             return True
         except BtrfsError:
             return False
-        except Exception:
-            # Unexpected error - could indicate system issues
-            return False
 
-    @btrfs_operation(BtrfsSubvolumeError, "Failed to create snapshot", timeout=120)
     def snapshot(self, target, readonly=False):
         """Create a snapshot of this subvolume"""
         cmd = ["btrfs", "subvolume", "snapshot"]
         if readonly:
             cmd.append("-r")
         cmd.extend([self.path, target])
-        return cmd
-
-    @btrfs_operation(BtrfsSubvolumeError, "Failed to create subvolume", timeout=120)
-    def _create_subvolume(self):
-        """Create the BTRFS subvolume"""
-        return ["btrfs", "subvolume", "create", self.path]
+        return run_safe(cmd, timeout=SNAPSHOT_TIMEOUT, error=BtrfsSubvolumeError)
 
     def create(self, cow=False):
         """Create a new BTRFS subvolume"""
-        out = self._create_subvolume()
+        out = run_safe(
+            ["btrfs", "subvolume", "create", self.path],
+            timeout=CREATE_TIMEOUT,
+            error=BtrfsSubvolumeError,
+        )
         if not cow:
             with contextlib.suppress(BtrfsError):
-                run_safe(["chattr", "+C", self.path], timeout=10)
+                run_safe(["chattr", "+C", self.path], timeout=CHATTR_TIMEOUT)
                 # chattr failure is not critical, subvolume was created successfully
         return out
 
-    @btrfs_operation(BtrfsSubvolumeError, "Failed to delete subvolume", timeout=300)
-    def _delete_subvolume(self):
-        """Delete the BTRFS subvolume"""
-        return ["btrfs", "subvolume", "delete", self.path]
-
-    def delete(self, check=True):
+    def delete(self):
         """Delete this BTRFS subvolume
 
-        :param check: if True, in case btrfs subvolume fails (exit code != 0)
-                      an exception will be raised
         :return: btrfs output string
         """
-        if check:
-            return self._delete_subvolume()
-        else:
-            # Silent failure mode
-            try:
-                return run_safe(
-                    ["btrfs", "subvolume", "delete", self.path],
-                    check=False,
-                    timeout=300,
-                )
-            except Exception:
-                return ""
+        return run_safe(
+            ["btrfs", "subvolume", "delete", self.path],
+            timeout=DELETE_TIMEOUT,
+            error=BtrfsSubvolumeError,
+        )
 
 
 class Filesystem:
@@ -185,7 +127,7 @@ class Filesystem:
         self.path = path
 
     def label(self, label=None):
-        if label is None:
-            return run_safe(["btrfs", "filesystem", "label", self.path], timeout=15)
-        else:
-            return run_safe(["btrfs", "filesystem", "label", self.path, label], timeout=15)
+        cmd = ["btrfs", "filesystem", "label", self.path]
+        if label is not None:
+            cmd.append(label)
+        return run_safe(cmd, timeout=LABEL_TIMEOUT)

--- a/buttervolume/plugin.py
+++ b/buttervolume/plugin.py
@@ -7,16 +7,12 @@ import re
 import subprocess
 from datetime import datetime
 from os.path import basename, dirname, join
-from subprocess import PIPE, run
+from subprocess import run
 
 from bottle import request, route
 
 from buttervolume import btrfs
-from buttervolume.btrfs import (
-    BtrfsError,
-    BtrfsFilesystemError,
-    BtrfsSubvolumeError,
-)
+from buttervolume.btrfs import BtrfsError
 
 
 # Custom exceptions for better error handling
@@ -93,6 +89,9 @@ if not os.path.exists(USOCKET):
             continue  # Try next driver name
 
 TIMER = int(getconfig(config, "TIMER", 60))
+# How long each external command may legitimately take, in seconds
+SYNC_TIMEOUT = 30
+RSYNC_TIMEOUT = 600
 DTFORMAT = getconfig(config, "DTFORMAT", "%Y-%m-%dT%H:%M:%S.%f")
 LOGLEVEL = getattr(logging, getconfig(config, "LOGLEVEL", "INFO"))
 
@@ -172,8 +171,6 @@ def safe_handler(func):
             VolumeNotFoundError,
             SnapshotNotFoundError,
             ReplicationError,
-            BtrfsSubvolumeError,
-            BtrfsFilesystemError,
             BtrfsError,
         ) as e:
             return {"Err": str(e)}
@@ -194,7 +191,7 @@ def run_btrfs_send_receive(
     validate_hostname(remote_host)
 
     # First sync the filesystem
-    btrfs.run_safe(["btrfs", "filesystem", "sync", SNAPSHOTS_PATH], timeout=30)
+    btrfs.run_safe(["btrfs", "filesystem", "sync", SNAPSHOTS_PATH], timeout=SYNC_TIMEOUT)
 
     # Build btrfs send command
     send_cmd = ["btrfs", "send"]
@@ -411,8 +408,7 @@ def volume_sync(req):
             ]
             log.debug("Running %r", cmd)
             try:
-                # 10 min timeout for rsync
-                btrfs.run_safe(cmd, check=True, stdout=PIPE, stderr=PIPE, timeout=600)
+                btrfs.run_safe(cmd, timeout=RSYNC_TIMEOUT)
             except Exception as ex:
                 err = getattr(ex, "stderr", str(ex))
                 if isinstance(err, bytes):

--- a/test.py
+++ b/test.py
@@ -720,6 +720,11 @@ class TestCase(unittest.TestCase):
         # the original failure stays reachable instead of being swallowed
         self.assertIsInstance(caught.exception.__cause__, CalledProcessError)
 
+    def test_run_safe_missing_command(self):
+        """A command that cannot even be started is reported like any other failure"""
+        with self.assertRaises(btrfs.BtrfsError):
+            btrfs.run_safe(["there_is_no_such_command"], timeout=btrfs.SHOW_TIMEOUT)
+
     def test_compute_purge(self):
         now = datetime.now()
         snapshots = [

--- a/test.py
+++ b/test.py
@@ -12,7 +12,7 @@ import weakref
 from contextlib import suppress
 from datetime import datetime, timedelta
 from os.path import join
-from subprocess import check_output, run
+from subprocess import CalledProcessError, check_output, run
 from unittest.mock import MagicMock, patch
 
 from webtest import TestApp
@@ -57,7 +57,7 @@ class TestCase(unittest.TestCase):
                             if os.path.isdir(item_path):
                                 # Try BTRFS subvolume deletion first
                                 try:
-                                    btrfs.Subvolume(item_path).delete(check=False)
+                                    btrfs.Subvolume(item_path).delete()
                                 except Exception:
                                     # If BTRFS deletion fails, try regular directory removal
 
@@ -636,7 +636,7 @@ class TestCase(unittest.TestCase):
                         item_path = join(SNAPSHOTS_PATH, item)
                         # Continue cleanup even if individual items fail
                         with suppress(Exception):
-                            btrfs.Subvolume(item_path).delete(check=False)
+                            btrfs.Subvolume(item_path).delete()
 
         self.create_20_hourly_snapshots(name)
         # run the purge with a simple save pattern (2h only)
@@ -706,6 +706,19 @@ class TestCase(unittest.TestCase):
         self.assertEqual(len(os.listdir(SNAPSHOTS_PATH)), nb_snaps - 18)
         cleanup_snapshots()
         self.app.post("/VolumeDriver.Remove", json.dumps({"Name": name}))
+
+    def test_run_safe_typed_error(self):
+        """A failed command raises the requested type, and says which command failed"""
+        missing = join(VOLUMES_PATH, "there_is_no_such_volume")
+        with self.assertRaises(btrfs.BtrfsSubvolumeError) as caught:
+            btrfs.run_safe(
+                ["btrfs", "subvolume", "show", missing],
+                timeout=btrfs.SHOW_TIMEOUT,
+                error=btrfs.BtrfsSubvolumeError,
+            )
+        self.assertIn(missing, str(caught.exception))
+        # the original failure stays reachable instead of being swallowed
+        self.assertIsInstance(caught.exception.__cause__, CalledProcessError)
 
     def test_compute_purge(self):
         now = datetime.now()


### PR DESCRIPTION
Two guards ran side by side in `btrfs.py`: `run_safe`, and a `btrfs_operation` decorator whose body was the same try/except with a choice of error class. The decorator also inverted the call, since a decorated method had to return a command list instead of running it, which forced `create` and `delete` to each grow a private twin method.

`run_safe` now takes the error class as a parameter, which leaves the decorator with nothing to offer, and the twin methods go with it. The original exception is kept as the cause instead of being dropped, and every delay is a named constant instead of a number in the call.

`delete` loses its `check=False` mode: it returned an empty string on a deletion that had failed, and the caller could not tell that apart from a success.

`BtrfsFilesystemError` and `InvalidPathError` are gone too, since nothing ever raised them.

Test: `test_run_safe_typed_error` checks that a failing command raises the class the caller asked for, names the command, and keeps the original error reachable as the cause. `test_local.sh` is green (17 passed, 4 replication tests skipped for lack of SSH).