### PR TITLE
Stop the purge tests from depending on their own duration

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ CHANGELOG
 3.13 (unreleased)
 *****************
 
+- Fixed the purge tests, which passed or failed depending on how long they took
+  to run.
 - Fixed the tests: create a BTRFS filesystems in a loop device if there is no BTRFS during tests.
 - Fixed the show command
 - Updated dependencies

--- a/test.py
+++ b/test.py
@@ -601,7 +601,13 @@ class TestCase(unittest.TestCase):
 
     def create_20_hourly_snapshots(self, name):
         path = join(VOLUMES_PATH, name)
-        hours = [(datetime.now() - timedelta(hours=h)).strftime(DTFORMAT) for h in range(20)]
+        # Five minutes short of the round hour: a snapshot exactly as old as a
+        # purge threshold falls on either side of it depending on how long the
+        # test itself takes, which made the expected counts below a coin flip.
+        hours = [
+            (datetime.now() - timedelta(hours=h) + timedelta(minutes=5)).strftime(DTFORMAT)
+            for h in range(20)
+        ]
         for h in hours:
             run(
                 f"btrfs subvolume snapshot {path} {join(SNAPSHOTS_PATH, name)}@{h}",
@@ -671,8 +677,8 @@ class TestCase(unittest.TestCase):
             json.dumps({"Name": name, "Pattern": "2h:4h:8h:16h"}),
         )
         self.assertEqual(jsonloads(resp.body), {"Err": ""})
-        # check we deleted 15 snapshots
-        self.assertEqual(len(os.listdir(SNAPSHOTS_PATH)), nb_snaps - 15)
+        # check we deleted 14 snapshots
+        self.assertEqual(len(os.listdir(SNAPSHOTS_PATH)), nb_snaps - 14)
 
         cleanup_snapshots()
         self.create_20_hourly_snapshots(name)
@@ -702,8 +708,8 @@ class TestCase(unittest.TestCase):
             json.dumps({"Name": name, "Pattern": "60m:120m:180m:240m:300m"}),
         )
         self.assertEqual(jsonloads(resp.body), {"Err": ""})
-        # check we deleted 18 snapshots
-        self.assertEqual(len(os.listdir(SNAPSHOTS_PATH)), nb_snaps - 18)
+        # check we deleted 15 snapshots
+        self.assertEqual(len(os.listdir(SNAPSHOTS_PATH)), nb_snaps - 15)
         cleanup_snapshots()
         self.app.post("/VolumeDriver.Remove", json.dumps({"Name": name}))
 


### PR DESCRIPTION
The twenty snapshots of the purge fixture were created exactly on the round hour, so each one had exactly the age of a purge threshold. The purge itself happens a moment later, and that moment was enough to push a snapshot past its threshold: the tests passed on a fast machine and failed on a slower one. This is what makes the continuous integration red on some branches and green on others, for the same code.

The failure looks like this: `test_purge` expects seventeen snapshots to be deleted with the pattern `2h`, and eighteen are deleted as soon as the fixture takes more than one second, because the snapshot aged exactly two hours becomes two hours and one second old.

The fixture now places the snapshots five minutes short of the round hour, far enough from every threshold for the counts to be identical whatever the machine. The expected numbers change for the two multi-component patterns, because the old numbers described what happens exactly on a threshold, which is not what the tests meant to check and not a situation that occurs in practice.

Proof: with an artificial three second delay added to the fixture, `test_purge` fails on master (`AssertionError: 4 != 5`) and passes with this change. Full local suite: 16 passed, 4 skipped (the SSH replication tests, as usual locally).