### PR TITLE
Let git merge the changelog by keeping both sides

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# The changelog only ever grows by a line at the top, and every branch adds
+# one there. Keeping both sides is always the right answer, and saves a
+# conflict on every single merge.
+CHANGES.rst merge=union


### PR DESCRIPTION
Every branch adds its line at the top of the unreleased section of `CHANGES.rst`, so two branches always touch the same place, and every merge or rebase stops on the same conflict. That conflict has only ever had one resolution: keep both lines.

Git ships with a merge driver that does exactly that, and a single line in `.gitattributes` turns it on for the changelog alone. Nothing to install and nothing to configure locally, since the attribute travels with the repository.

Checked on a scratch repository: two branches each adding an entry at the top merge without a conflict, and both entries are present afterwards. The order of the two lines follows the order of the merge, which the changelog does not care about.

Only `CHANGES.rst` is covered. Keeping both sides is the right answer for a list of independent lines, and the wrong answer for source code, so the rule stays on that one file.