### PR TITLE
Give volume and snapshot names their own module

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,14 @@ subvolumes: snapshot, restore, clone, replicate. Python, Bottle, argparse.
   the authoritative route list. `@route` is defined there too, and is not
   Bottle's: it decodes the request, logs it, and turns any failure into the
   `Err` field of a 200 answer, which is the only shape a client can read.
+- `buttervolume/names.py`: what a volume name and a snapshot name are worth.
+  `volume@timestamp`, plus `@host` for the trace of a send, is read and written
+  here alone, and the validation lives here too. Pure functions: no disk, no
+  configuration, the date format arrives as an argument. The paths stay in
+  `plugin.py`, which is where the directories are configured, and a name is
+  validated there as it becomes a path.
+- `buttervolume/__init__.py`: the errors the API answers with. They sit below
+  everything so that both `names.py` and `plugin.py` can raise them.
 - `buttervolume/btrfs.py`: the subvolume operations, and `run_safe`, the guarded
   way to call the `btrfs` command. One path escapes it and needs the same care:
   `run_btrfs_send_receive` in `plugin.py` builds its own send and receive to

--- a/buttervolume/__init__.py
+++ b/buttervolume/__init__.py
@@ -1,0 +1,31 @@
+"""The errors Buttervolume answers with.
+
+They live here rather than in `plugin.py` because the modules below it, such
+as the naming rules, raise them too, and importing the plugin from there would
+close a circle. `BtrfsError` is the exception: it belongs to `btrfs.py`, which
+knows nothing of volumes.
+"""
+
+
+class ButtervolumeError(Exception):
+    """Base exception for Buttervolume errors"""
+
+
+class VolumeNotFoundError(ButtervolumeError):
+    """Raised when a volume is not found"""
+
+
+class SnapshotNotFoundError(ButtervolumeError):
+    """Raised when a snapshot is not found"""
+
+
+class ValidationError(ButtervolumeError):
+    """Raised when input validation fails"""
+
+
+class ReplicationError(ButtervolumeError):
+    """Raised when replication fails"""
+
+
+class ReplicationTimeoutError(ReplicationError):
+    """Raised when a replication is killed for taking too long"""

--- a/buttervolume/names.py
+++ b/buttervolume/names.py
@@ -157,8 +157,14 @@ def parsed(names):
 
 
 def snapshots_of(volume, names):
-    """The names among these that are snapshots of this volume, oldest first."""
-    return sorted(str(s) for s in parsed(names) if s.volume == volume)
+    """The names among these that are snapshots of this volume, oldest first.
+
+    A name we could not have written is kept, not quietly dropped: hiding it
+    would let the caller believe it has seen everything, and pick the second
+    most recent snapshot thinking it is the most recent one. It is refused
+    later, when it becomes a path, and then the answer says so.
+    """
+    return sorted(n for n in names if n.startswith(volume + "@"))
 
 
 def sent_snapshots(volume, host, names):

--- a/buttervolume/names.py
+++ b/buttervolume/names.py
@@ -1,0 +1,169 @@
+"""How volumes and snapshots are named, and how a name is read back.
+
+A volume is named ``www``. A snapshot of it carries the moment it was taken:
+``www@2026-08-26T10:00:00.000000``. Once that snapshot has been sent to a
+host, the trace kept locally to serve as parent for the next send adds the
+target: ``www@2026-08-26T10:00:00.000000@node2``.
+
+Nothing here touches the disk and nothing here reads the configuration: the
+date and its format arrive as arguments. A name is a name, valid or not, long
+before anything is created with it.
+"""
+
+import re
+from dataclasses import dataclass, replace
+from datetime import datetime
+
+from buttervolume import ValidationError
+
+
+def validate_volume_name(name):
+    """Validate volume name for security and correctness"""
+    if not name:
+        raise ValidationError("Volume name cannot be empty")
+
+    if "@" in name:
+        raise ValidationError('"@" is illegal in a volume name')
+
+    # Check for path traversal
+    if ".." in name or name.startswith("/"):
+        raise ValidationError("Invalid characters in volume name")
+
+    # Check for dangerous shell characters
+    dangerous_chars = [
+        "`",
+        "$",
+        "|",
+        "&",
+        ";",
+        ">",
+        "<",
+        "*",
+        "?",
+        "[",
+        "]",
+        "(",
+        ")",
+        "{",
+        "}",
+        "\\",
+    ]
+    if any(char in name for char in dangerous_chars):
+        raise ValidationError("Volume name contains dangerous characters")
+
+    # Ensure reasonable length
+    if len(name) > 255:
+        raise ValidationError("Volume name too long")
+
+    # Only allow alphanumeric, dash, underscore, dot
+    if not re.fullmatch(r"[a-zA-Z0-9._-]+", name):
+        raise ValidationError("Volume name contains invalid characters")
+
+    return name
+
+
+def validate_snapshot_name(name):
+    """Validate a snapshot name: volume@timestamp, plus @host for sent snapshots.
+
+    Snapshot names come from Docker or from a remote host and end up in a
+    path and in a shell command, so they get the same care as volume names.
+    """
+    if not name:
+        raise ValidationError("Snapshot name cannot be empty")
+
+    if len(name) > 255:
+        raise ValidationError("Snapshot name too long")
+
+    parts = name.split("@")
+    if len(parts) not in (2, 3):
+        raise ValidationError("Invalid snapshot name format")
+
+    validate_volume_name(parts[0])
+    for part in parts[1:]:
+        if not part or not re.fullmatch(r"[a-zA-Z0-9.:_-]+", part):
+            raise ValidationError("Snapshot name contains invalid characters")
+
+    return name
+
+
+def validate_hostname(hostname):
+    """Validate hostname for SSH operations"""
+    if not hostname:
+        raise ValidationError("Hostname cannot be empty")
+
+    # Basic hostname validation
+    if not re.fullmatch(r"[a-zA-Z0-9.-]+", hostname):
+        raise ValidationError("Invalid hostname format")
+
+    if len(hostname) > 253:
+        raise ValidationError("Hostname too long")
+
+    return hostname
+
+
+@dataclass(frozen=True)
+class Snapshot:
+    """A snapshot name, read: the volume, the moment, and the target of a send.
+
+    It is only built by parse(), so a name with four parts or an empty
+    timestamp never becomes one of these.
+    """
+
+    volume: str
+    timestamp: str
+    host: str | None = None
+
+    @classmethod
+    def parse(cls, name):
+        return cls(*validate_snapshot_name(name).split("@"))
+
+    def __str__(self):
+        return "@".join(p for p in (self.volume, self.timestamp, self.host) if p)
+
+    def taken_at(self, dtformat):
+        """The moment this snapshot was taken, as written by new_snapshot."""
+        return datetime.strptime(self.timestamp, dtformat)
+
+    def sent_to(self, host):
+        """The trace to keep locally once this snapshot has been sent there."""
+        return replace(self, host=validate_hostname(host))
+
+    def without_host(self):
+        """The snapshot this trace was made from, which is its own parent."""
+        return replace(self, host=None)
+
+
+def new_snapshot(volume, dtformat, now):
+    """Name a new snapshot of this volume, as the API will have to read it back.
+
+    The date format is configurable, so a format holding a space or a plus
+    sign would build a name the validation rejects: the snapshot would exist
+    and no endpoint could name it again. Better to refuse to create it.
+    """
+    return Snapshot.parse(f"{volume}@{now.strftime(dtformat)}")
+
+
+def parsed(names):
+    """These names, read; the ones that are not snapshot names are left out.
+
+    The snapshots directory is read with listdir, and nothing promises that
+    everything sitting there was put there by us.
+    """
+    for name in names:
+        try:
+            yield Snapshot.parse(name)
+        except ValidationError:
+            continue
+
+
+def snapshots_of(volume, names):
+    """The names among these that are snapshots of this volume, oldest first."""
+    return sorted(str(s) for s in parsed(names) if s.volume == volume)
+
+
+def sent_snapshots(volume, host, names):
+    """The traces of the sends of this volume to this host, oldest first."""
+    return sorted(
+        (s for s in parsed(names) if s.volume == volume and s.host == host),
+        key=str,
+    )

--- a/buttervolume/plugin.py
+++ b/buttervolume/plugin.py
@@ -388,6 +388,13 @@ def snapshot_send(req):
     remote_host = req["Host"]
 
     snapshot = Snapshot.parse(snapshot_name)
+    if snapshot.host:
+        # sending a trace would name its own trace, and btrfs would refuse
+        # once the transfer is already done
+        raise ValidationError(
+            f"'{snapshot_name}' is the trace of a send to {snapshot.host}, "
+            "not a snapshot that can be sent"
+        )
     validate_hostname(remote_host)
 
     snapshot_path = snapshotpath(snapshot_name)

--- a/buttervolume/plugin.py
+++ b/buttervolume/plugin.py
@@ -15,46 +15,16 @@ from subprocess import run
 from bottle import request
 from bottle import route as bottle_route
 
-from buttervolume import btrfs
+from buttervolume import (
+    ButtervolumeError,  # noqa: F401  (re-exported: the API answers with these)
+    ReplicationError,
+    ReplicationTimeoutError,
+    SnapshotNotFoundError,
+    ValidationError,
+    VolumeNotFoundError,
+    btrfs,
+)
 from buttervolume.btrfs import BtrfsError
-
-
-# Custom exceptions for better error handling
-class ButtervolumeError(Exception):
-    """Base exception for Buttervolume errors"""
-
-    pass
-
-
-class VolumeNotFoundError(ButtervolumeError):
-    """Raised when a volume is not found"""
-
-    pass
-
-
-class SnapshotNotFoundError(ButtervolumeError):
-    """Raised when a snapshot is not found"""
-
-    pass
-
-
-class ValidationError(ButtervolumeError):
-    """Raised when input validation fails"""
-
-    pass
-
-
-class ReplicationError(ButtervolumeError):
-    """Raised when replication fails"""
-
-    pass
-
-
-class ReplicationTimeoutError(ReplicationError):
-    """Raised when a replication is killed for taking too long"""
-
-    pass
-
 
 config = configparser.ConfigParser()
 config.read("/etc/buttervolume/config.ini")

--- a/buttervolume/plugin.py
+++ b/buttervolume/plugin.py
@@ -3,7 +3,6 @@ import csv
 import json
 import logging
 import os
-import re
 import subprocess
 import tempfile
 import time
@@ -16,7 +15,6 @@ from bottle import request
 from bottle import route as bottle_route
 
 from buttervolume import (
-    ButtervolumeError,  # noqa: F401  (re-exported: the API answers with these)
     ReplicationError,
     ReplicationTimeoutError,
     SnapshotNotFoundError,
@@ -25,6 +23,15 @@ from buttervolume import (
     btrfs,
 )
 from buttervolume.btrfs import BtrfsError
+from buttervolume.names import (
+    Snapshot,
+    new_snapshot,
+    sent_snapshots,
+    snapshots_of,
+    validate_hostname,
+    validate_snapshot_name,
+    validate_volume_name,
+)
 
 config = configparser.ConfigParser()
 config.read("/etc/buttervolume/config.ini")
@@ -81,98 +88,31 @@ logging.basicConfig(level=LOGLEVEL)
 log = logging.getLogger()
 
 
-def validate_volume_name(name):
-    """Validate volume name for security and correctness"""
-    if not name:
-        raise ValidationError("Volume name cannot be empty")
+def volumepath(name):
+    """The path of this volume, whether or not it exists.
 
-    if "@" in name:
-        raise ValidationError('"@" is illegal in a volume name')
-
-    # Check for path traversal
-    if ".." in name or name.startswith("/"):
-        raise ValidationError("Invalid characters in volume name")
-
-    # Check for dangerous shell characters
-    dangerous_chars = [
-        "`",
-        "$",
-        "|",
-        "&",
-        ";",
-        ">",
-        "<",
-        "*",
-        "?",
-        "[",
-        "]",
-        "(",
-        ")",
-        "{",
-        "}",
-        "\\",
-    ]
-    if any(char in name for char in dangerous_chars):
-        raise ValidationError("Volume name contains dangerous characters")
-
-    # Ensure reasonable length
-    if len(name) > 255:
-        raise ValidationError("Volume name too long")
-
-    # Only allow alphanumeric, dash, underscore, dot
-    if not re.fullmatch(r"[a-zA-Z0-9._-]+", name):
-        raise ValidationError("Volume name contains invalid characters")
-
-    return name
-
-
-def validate_snapshot_name(name):
-    """Validate a snapshot name: volume@timestamp, plus @host for sent snapshots.
-
-    Snapshot names come from Docker or from a remote host and end up in a
-    path and in a shell command, so they get the same care as volume names.
+    A name becomes a path here and nowhere else, so this is also where it is
+    checked: no handler downstream has to remember to do it.
     """
-    if not name:
-        raise ValidationError("Snapshot name cannot be empty")
+    return join(VOLUMES_PATH, validate_volume_name(name))
 
-    if len(name) > 255:
-        raise ValidationError("Snapshot name too long")
 
-    parts = name.split("@")
-    if len(parts) not in (2, 3):
-        raise ValidationError("Invalid snapshot name format")
+def existing_volume(name):
+    """The subvolume of this volume, or a clear error when there is none."""
+    subvolume = btrfs.Subvolume(volumepath(name))
+    if not subvolume.exists():
+        raise VolumeNotFoundError(f"Volume '{name}': no such volume")
+    return subvolume
 
-    validate_volume_name(parts[0])
-    for part in parts[1:]:
-        if not part or not re.fullmatch(r"[a-zA-Z0-9.:_-]+", part):
-            raise ValidationError("Snapshot name contains invalid characters")
 
-    return name
+def snapshotpath(name):
+    """The path of this snapshot, whether or not it exists."""
+    return join(SNAPSHOTS_PATH, validate_snapshot_name(name))
 
 
 def new_snapshot_name(volume_name):
-    """Name a new snapshot of this volume, as the API will have to read it back.
-
-    DTFORMAT is configurable, so a format holding a space or a plus sign would
-    build a name the validation above rejects: the snapshot would exist and no
-    endpoint could name it again. Better to refuse to create it.
-    """
-    return validate_snapshot_name(f"{volume_name}@{datetime.now().strftime(DTFORMAT)}")
-
-
-def validate_hostname(hostname):
-    """Validate hostname for SSH operations"""
-    if not hostname:
-        raise ValidationError("Hostname cannot be empty")
-
-    # Basic hostname validation
-    if not re.fullmatch(r"[a-zA-Z0-9.-]+", hostname):
-        raise ValidationError("Invalid hostname format")
-
-    if len(hostname) > 253:
-        raise ValidationError("Hostname too long")
-
-    return hostname
+    """Name a new snapshot of this volume, using the configured date format."""
+    return str(new_snapshot(volume_name, DTFORMAT, datetime.now()))
 
 
 def answer(handler, kw):
@@ -301,9 +241,7 @@ def volume_create(req):
     name = req["Name"]
     opts = req.get("Opts", {}) or {}
 
-    validate_volume_name(name)
-
-    volpath = join(VOLUMES_PATH, name)
+    volpath = volumepath(name)
     # volume already exists?
     if name in [v["Name"] for v in list_volumes()["Volumes"]]:
         return {"Err": ""}
@@ -333,27 +271,14 @@ def volume_create(req):
     return {"Err": ""}
 
 
-def volumepath(name):
-    path = join(VOLUMES_PATH, name)
-    if not btrfs.Subvolume(path).exists():
-        raise VolumeNotFoundError(f"Volume '{name}': no such volume")
-    return path
-
-
 @route("/VolumeDriver.Mount")
 def volume_mount(req):
-    name = req["Name"]
-    validate_volume_name(name)
-    path = volumepath(name)
-    return {"Mountpoint": path, "Err": ""}
+    return {"Mountpoint": existing_volume(req["Name"]).path, "Err": ""}
 
 
 @route("/VolumeDriver.Path")
 def volume_path(req):
-    name = req["Name"]
-    validate_volume_name(name)
-    path = volumepath(name)
-    return {"Mountpoint": path, "Err": ""}
+    return {"Mountpoint": existing_volume(req["Name"]).path, "Err": ""}
 
 
 @route("/VolumeDriver.Unmount")
@@ -364,19 +289,12 @@ def volume_unmount(_):
 @route("/VolumeDriver.Get")
 def volume_get(req):
     name = req["Name"]
-    validate_volume_name(name)
-    path = volumepath(name)
-    return {"Volume": {"Name": name, "Mountpoint": path}, "Err": ""}
+    return {"Volume": {"Name": name, "Mountpoint": existing_volume(name).path}, "Err": ""}
 
 
 @route("/VolumeDriver.Remove")
 def volume_remove(req):
-    name = req["Name"]
-    validate_volume_name(name)
-    path = join(VOLUMES_PATH, name)
-    if not btrfs.Subvolume(path).exists():
-        raise VolumeNotFoundError(f"Volume '{name}': no such volume")
-    btrfs.Subvolume(path).delete()
+    existing_volume(req["Name"]).delete()
     return {"Err": ""}
 
 
@@ -423,7 +341,7 @@ def volume_sync(req):
         return {"Err": "\n".join(errors)}
 
     for volume_name in volumes:
-        local_volume_path = join(VOLUMES_PATH, volume_name)
+        local_volume_path = volumepath(volume_name)
         remote_volume_path = join(remote_volumes, volume_name)
         for remote_host in remote_hosts:
             log.debug("Rsync volume: %s from host: %s", local_volume_path, remote_host)
@@ -469,27 +387,17 @@ def snapshot_send(req):
     snapshot_name = req["Name"]
     remote_host = req["Host"]
 
-    validate_snapshot_name(snapshot_name)
+    snapshot = Snapshot.parse(snapshot_name)
     validate_hostname(remote_host)
 
-    snapshot_path = join(SNAPSHOTS_PATH, snapshot_name)
+    snapshot_path = snapshotpath(snapshot_name)
     remote_snapshots = SNAPSHOTS_PATH if not test else TEST_REMOTE_PATH
 
-    # take the latest snapshot suffixed with the target host
-    sent_snapshots = sorted(
-        [
-            s
-            for s in os.listdir(SNAPSHOTS_PATH)
-            if len(s.split("@")) == 3
-            and s.split("@")[0] == snapshot_name.split("@")[0]
-            and s.split("@")[2] == remote_host
-        ]
-    )
-    latest = sent_snapshots[-1] if len(sent_snapshots) > 0 else None
-    if latest and len(latest.rsplit("@")) == 3:
-        latest = latest.rsplit("@", 1)[0]
-
-    parent_path = join(SNAPSHOTS_PATH, latest) if latest else None
+    # the previous send to that host left a trace: its snapshot is the parent
+    # this one can be sent against
+    already_sent = sent_snapshots(snapshot.volume, remote_host, os.listdir(SNAPSHOTS_PATH))
+    latest = str(already_sent[-1].without_host()) if already_sent else None
+    parent_path = snapshotpath(latest) if latest else None
     port = os.getenv("SSH_PORT", "1122")
 
     try:
@@ -522,14 +430,16 @@ def snapshot_send(req):
         run_btrfs_send_receive(snapshot_path, remote_host, remote_snapshots, None, port)
 
     # Create local tracking snapshot
-    btrfs.Subvolume(snapshot_path).snapshot(f"{snapshot_path}@{remote_host}", readonly=True)
+    btrfs.Subvolume(snapshot_path).snapshot(
+        snapshotpath(str(snapshot.sent_to(remote_host))), readonly=True
+    )
 
     # Clean up old tracking snapshots
-    for old_snapshot in sent_snapshots:
+    for old_snapshot in already_sent:
         try:
-            btrfs.Subvolume(join(SNAPSHOTS_PATH, old_snapshot)).delete()
+            btrfs.Subvolume(snapshotpath(str(old_snapshot))).delete()
         except Exception as e:
-            log.warning("Failed to delete old snapshot %s: %s", old_snapshot, str(e))
+            log.warning("Failed to delete old snapshot %s: %s", str(old_snapshot), str(e))
 
     return {"Err": ""}
 
@@ -538,16 +448,10 @@ def snapshot_send(req):
 def volume_snapshot(req):
     """snapshot a volume in the SNAPSHOTS dir"""
     name = req["Name"]
-    validate_volume_name(name)
-
-    path = join(VOLUMES_PATH, name)
-    if not os.path.exists(path) or not btrfs.Subvolume(path).exists():
-        raise VolumeNotFoundError(f"Volume '{name}': no such volume")
+    volume = existing_volume(name)
 
     timestamped = new_snapshot_name(name)
-    snapshot_path = join(SNAPSHOTS_PATH, timestamped)
-
-    btrfs.Subvolume(path).snapshot(snapshot_path, readonly=True)
+    volume.snapshot(snapshotpath(timestamped), readonly=True)
     return {"Err": "", "Snapshot": timestamped}
 
 
@@ -559,22 +463,16 @@ def snapshot_list(_):
 
 @route("/VolumeDriver.Snapshot.List/<name>", "GET")
 def snapshot_sublist(_, name=""):
-    # Validate volume name if provided
-    if name:
-        validate_volume_name(name)
-
     snapshots = os.listdir(SNAPSHOTS_PATH)
     if name:
-        snapshots = [s for s in snapshots if s.startswith(name + "@")]
+        snapshots = snapshots_of(validate_volume_name(name), snapshots)
     return {"Err": "", "Snapshots": snapshots}
 
 
 @route("/VolumeDriver.Snapshot.Remove")
 def snapshot_delete(req):
     name = req["Name"]
-    validate_snapshot_name(name)
-
-    path = join(SNAPSHOTS_PATH, name)
+    path = snapshotpath(name)
     if not os.path.exists(path):
         raise SnapshotNotFoundError(f"Snapshot '{name}' not found")
 
@@ -655,25 +553,19 @@ def snapshot_restore(req):
 
     if "@" not in snapshot_name:
         # we're passing the name of the volume. Use the latest snapshot.
-        volume_name = snapshot_name
-        validate_volume_name(volume_name)
-        snapshots = os.listdir(SNAPSHOTS_PATH)
-        snapshots = [s for s in snapshots if s.startswith(volume_name + "@")]
+        volume_name = validate_volume_name(snapshot_name)
+        snapshots = snapshots_of(volume_name, os.listdir(SNAPSHOTS_PATH))
         if not snapshots:
             raise SnapshotNotFoundError(f"No snapshots found for volume '{volume_name}'")
-        snapshot_name = sorted(snapshots)[-1]
-    else:
-        validate_snapshot_name(snapshot_name)
+        snapshot_name = snapshots[-1]
 
-    snapshot_path = join(SNAPSHOTS_PATH, snapshot_name)
+    snapshot_path = snapshotpath(snapshot_name)
     if not os.path.exists(snapshot_path):
         raise SnapshotNotFoundError(f"Snapshot '{snapshot_name}' not found")
 
     snapshot = btrfs.Subvolume(snapshot_path)
-    target_name = target_name or snapshot_name.split("@")[0]
-    validate_volume_name(target_name)
-
-    target_path = join(VOLUMES_PATH, target_name)
+    target_name = target_name or Snapshot.parse(snapshot_name).volume
+    target_path = volumepath(target_name)
     volume = btrfs.Subvolume(target_path)
     res = {"Err": ""}
 
@@ -683,8 +575,7 @@ def snapshot_restore(req):
     if volume.exists():
         # backup and delete
         stamped_name = new_snapshot_name(target_name)
-        stamped_path = join(SNAPSHOTS_PATH, stamped_name)
-        volume.snapshot(stamped_path, readonly=True)
+        volume.snapshot(snapshotpath(stamped_name), readonly=True)
         res["VolumeBackup"] = stamped_name
         volume.delete()
 
@@ -700,16 +591,8 @@ def snapshot_clone(req):
     volumename = req["Name"]
     targetname = req.get("Target")
 
-    # Validate input names
-    validate_volume_name(volumename)
-    validate_volume_name(targetname)
-
-    volumepath = join(VOLUMES_PATH, volumename)
-    targetpath = join(VOLUMES_PATH, targetname)
-
-    volume = btrfs.Subvolume(volumepath)
-    if not volume.exists():
-        raise VolumeNotFoundError(f"Source volume '{volumename}': no such volume")
+    volume = existing_volume(volumename)
+    targetpath = volumepath(targetname)
 
     # Check if target already exists
     target_volume = btrfs.Subvolume(targetpath)
@@ -726,11 +609,8 @@ def snapshots_purge(req):
     Purge snapshots with a retention pattern
     (see cli help)
     """
-    volume_name = req["Name"]
+    volume_name = validate_volume_name(req["Name"])
     dryrun = req.get("Dryrun", False)
-
-    # Validate volume name
-    validate_volume_name(volume_name)
 
     # Validate pattern with strict rules (no backward compatibility for immediate purge)
     warning = validate_purge_pattern(req["Pattern"], allow_backward_compat=False)
@@ -740,8 +620,7 @@ def snapshots_purge(req):
     # Parse pattern for compute_purges
     pattern = parse_purge_pattern(req["Pattern"])
 
-    # snapshots related to the volume, more recents first
-    snapshots = [s for s in os.listdir(SNAPSHOTS_PATH) if s.startswith(volume_name + "@")]
+    snapshots = snapshots_of(volume_name, os.listdir(SNAPSHOTS_PATH))
 
     # Compute which snapshots to purge
     now = datetime.now()
@@ -752,7 +631,7 @@ def snapshots_purge(req):
             log.info(f"(Dry run) Would delete snapshot {snapshot}")
         else:
             # Delete the BTRFS subvolume (xattrs are automatically deleted with it)
-            btrfs.Subvolume(join(SNAPSHOTS_PATH, snapshot)).delete()
+            btrfs.Subvolume(snapshotpath(snapshot)).delete()
             log.info(f"Deleted snapshot {snapshot}")
 
     return {"Err": ""}
@@ -860,13 +739,13 @@ def compute_purges(snapshots, pattern, now):
     valid_snapshots = []
     for s in snapshots:
         try:
-            snapshots_age.append(
-                int((now - datetime.strptime(s.split("@")[1], DTFORMAT)).total_seconds()) / 60
-            )
-            valid_snapshots.append(s)
-        except Exception:
+            age = now - Snapshot.parse(s).taken_at(DTFORMAT)
+        except (ValidationError, ValueError):
+            # a purge does not delete what it cannot date
             log.info("Skipping purge of %s with invalid date format", s)
             continue
+        snapshots_age.append(int(age.total_seconds()) / 60)
+        valid_snapshots.append(s)
     if not valid_snapshots:
         return purge_list
 

--- a/test.py
+++ b/test.py
@@ -641,6 +641,39 @@ class TestCase(unittest.TestCase):
             json.dumps({"Name": name, "Action": "replicate:localhost", "Timer": 0}),
         )
 
+    def test_restore_of_a_volume_takes_its_latest_snapshot_or_says_why_not(self):
+        """A snapshot nobody can name again hides no other one behind it"""
+        name = PREFIX_TEST_VOLUME + uuid.uuid4().hex
+        path = join(VOLUMES_PATH, name)
+        self.create_a_volume_with_a_file(name)
+        self.app.post("/VolumeDriver.Snapshot", json.dumps({"Name": name}))
+        # a snapshot from an older version, taken under a date format holding
+        # a space, and more recent than the one above
+        legacy = f"{name}@2999-01-01 00:00:00"
+        btrfs.Subvolume(path).snapshot(join(SNAPSHOTS_PATH, legacy), readonly=True)
+        with open(join(path, "foobar"), "w") as f:
+            f.write("modified foobar")
+        # restoring by volume name must not silently fall back to the snapshot
+        # underneath: the latest one is unusable, and the answer says so
+        resp = jsonloads(
+            self.app.post("/VolumeDriver.Snapshot.Restore", json.dumps({"Name": name})).body
+        )
+        self.assertTrue(resp["Err"])
+        with open(join(path, "foobar")) as f:
+            self.assertEqual(f.read(), "modified foobar")
+        # cleanup
+        btrfs.Subvolume(join(SNAPSHOTS_PATH, legacy)).delete()
+
+    def test_the_trace_of_a_send_cannot_be_sent(self):
+        """Sending it back would name its own trace, and only fail once sent"""
+        resp = jsonloads(
+            self.app.post(
+                "/VolumeDriver.Snapshot.Send",
+                json.dumps({"Name": "www@2026-01-01T00:00:00.000000@node2", "Host": "node2"}),
+            ).body
+        )
+        self.assertIn("trace of a send", resp["Err"])
+
     def test_restore(self):
         """Check we can restore a snapshot as a volume"""
         # create a volume with a file
@@ -1113,8 +1146,9 @@ class TestNames(unittest.TestCase):
     def test_the_snapshots_of_a_volume_are_its_own(self):
         names = ["www@t1", "wwwbis@t1", "www@t2@node2", "other@t3"]
         self.assertEqual(snapshots_of("www", names), ["www@t1", "www@t2@node2"])
-        # a directory nobody here created is left out rather than half read
-        self.assertEqual(snapshots_of("www", ["www@t 1", "www@t1"]), ["www@t1"])
+        # a name we could not have written is still shown: hiding it would let
+        # the caller take www@t1 for the most recent snapshot of the volume
+        self.assertEqual(snapshots_of("www", ["www@t 2", "www@t1"]), ["www@t 2", "www@t1"])
 
     def test_the_parent_of_a_send_is_the_last_one_sent_to_that_host(self):
         names = ["www@t1", "www@t2", "www@t1@node2", "www@t2@node2", "other@t3@node2"]

--- a/test.py
+++ b/test.py
@@ -17,8 +17,14 @@ from unittest.mock import MagicMock, patch
 
 from webtest import TestApp
 
-from buttervolume import btrfs, cli, plugin
+from buttervolume import ValidationError, btrfs, cli, plugin
 from buttervolume.cli import init_btrfs, runjobs
+from buttervolume.names import (
+    Snapshot,
+    new_snapshot,
+    sent_snapshots,
+    snapshots_of,
+)
 from buttervolume.plugin import (
     DTFORMAT,
     SNAPSHOTS_PATH,
@@ -1078,6 +1084,45 @@ class TestCase(unittest.TestCase):
     def test_capabilities(self):
         rsp = jsonloads(self.app.post("/VolumeDriver.Capabilities", "{}").body)
         self.assertEqual(rsp.get("Capabilities", {}).get("Scope"), "local")
+
+
+class TestNames(unittest.TestCase):
+    """The naming rules, read and written without touching a filesystem"""
+
+    def test_a_snapshot_name_survives_a_round_trip(self):
+        for name in ("www@2026-08-26T10:00:00.000000", "www@2026-08-26T10:00:00.000000@node2"):
+            self.assertEqual(str(Snapshot.parse(name)), name)
+        snapshot = Snapshot.parse("www@2026-08-26T10:00:00.000000")
+        self.assertEqual(snapshot.volume, "www")
+        self.assertEqual(snapshot.timestamp, "2026-08-26T10:00:00.000000")
+        self.assertIsNone(snapshot.host)
+        self.assertEqual(snapshot.taken_at(DTFORMAT), datetime(2026, 8, 26, 10, 0, 0))
+
+    def test_a_name_that_is_not_a_snapshot_name_is_refused(self):
+        for bad in ("", "www", "@", "www@", "a@b@c@d", "www@$(reboot)", "www@2026-08-26 10:00"):
+            with self.assertRaises(ValidationError, msg=f"{bad!r} was accepted"):
+                Snapshot.parse(bad)
+
+    def test_a_new_snapshot_is_named_after_the_moment_it_is_taken(self):
+        now = datetime(2026, 8, 26, 10, 0, 0)
+        self.assertEqual(str(new_snapshot("www", DTFORMAT, now)), "www@2026-08-26T10:00:00.000000")
+        # a date format the API could not read back is refused, not created
+        with self.assertRaises(ValidationError):
+            new_snapshot("www", "%Y-%m-%d %H:%M:%S", now)
+
+    def test_the_snapshots_of_a_volume_are_its_own(self):
+        names = ["www@t1", "wwwbis@t1", "www@t2@node2", "other@t3"]
+        self.assertEqual(snapshots_of("www", names), ["www@t1", "www@t2@node2"])
+        # a directory nobody here created is left out rather than half read
+        self.assertEqual(snapshots_of("www", ["www@t 1", "www@t1"]), ["www@t1"])
+
+    def test_the_parent_of_a_send_is_the_last_one_sent_to_that_host(self):
+        names = ["www@t1", "www@t2", "www@t1@node2", "www@t2@node2", "other@t3@node2"]
+        already_sent = sent_snapshots("www", "node2", names)
+        self.assertEqual([str(s) for s in already_sent], ["www@t1@node2", "www@t2@node2"])
+        self.assertEqual(str(already_sent[-1].without_host()), "www@t2")
+        # and the trace this send will leave behind
+        self.assertEqual(str(Snapshot.parse("www@t3").sent_to("node2")), "www@t3@node2")
 
 
 class TemporaryDirectory(tempfile.TemporaryDirectory):


### PR DESCRIPTION
A snapshot is named `volume@timestamp`, and the trace of a send to a host adds `@host`. Until now that shape was decoded by hand wherever it was needed: `split("@")[0]` for the volume, `split("@")[1]` for the date, `startswith(volume + "@")` for the snapshots of a volume, and, for the parent of an incremental send, a length test written twice, once with `rsplit` and no `maxsplit`, which is exactly `split` and reads like something else.

That vocabulary now lives in `buttervolume/names.py`, in pure functions: no disk, no configuration, the date format arrives as an argument. A `Snapshot` is only ever built by `parse`, so a name with four parts never becomes one, and the parent of a send is simply the last trace to that host without its host.

The paths stay in `plugin.py`, where the directories are configured, and that is now where a name is checked, because that is where it becomes a path. The fifteen scattered calls to `validate_volume_name` go away with it, and so do the three different ways of asking whether a volume exists: `existing_volume` answers that once, with one message.

The exceptions move down into `buttervolume/__init__.py`, so that both modules can raise them without importing each other in a circle.

## One behaviour is firmer than before

Sending a snapshot that already carries a host is refused up front, with a clear answer, instead of transferring the whole thing and only then naming a trace that would be the snapshot itself.

Listing the snapshots of a volume keeps every name, including one this version could not have written. A first attempt filtered those out; that would have let a volume whose latest snapshot came from an older version under an unusual date format be silently restored to the snapshot underneath. Such a name is refused a moment later, when it becomes a path, and the caller reads why.

## Tests

Five tests describe the module without touching a filesystem: the round trip of a name, the names that are refused, the naming of a new snapshot including the date format the API could not read back, the snapshots belonging to a volume, and the choice of the parent of a send.

Two more go through the API: restoring a volume whose latest snapshot is unusable answers an error and leaves the volume alone (it silently restored an older snapshot before the second commit), and the trace of a send cannot itself be sent.

`./test_local.sh`: 31 passed, 4 skipped (the replication tests, which need SSH).

## Found on the way, not fixed here

`snapshots_purge` selects the snapshots of a volume with a filter that also catches the traces of sends, `www@date@node2`, whose date the purge knows how to read. A purge can therefore delete the trace of the last send to a host, and the next send silently starts over in full instead of incrementally. That is a change of behaviour and deserves its own pull request.