### PR TITLE
Say what a retention pattern really is

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -572,10 +572,11 @@ without deleting them::
 ``<volume>`` is the name of the volume, not the full path. It is expected
 to live in ``/var/lib/buttervolume/volumes``.
 
-``<pattern>`` is the snapshot retention pattern. It is a semicolon-separated
+``<pattern>`` is the snapshot retention pattern. It is a colon-separated
 list of time length specifiers with a unit. Units can be ``m`` for minutes,
-``h`` for hours, ``d`` for days, ``w`` for weeks, ``y`` for years. The pattern
-should have at least 2 items.
+``h`` for hours, ``d`` for days, ``w`` for weeks, ``y`` for years. The
+specifiers must be given from the shortest to the longest, and a pattern of a
+single specifier is allowed.
 
 Here are a few examples of retention patterns:
 
@@ -589,8 +590,11 @@ Here are a few examples of retention patterns:
     keep all snapshots during the last four hours, then one snapshot every
     four hours during the first week, then delete older snapshots.
 
-- ``2h:2h``
+- ``2h``
     keep all snapshots during the last two hours, then delete older snapshots.
+    Older versions of Buttervolume wrote this pattern ``2h:2h``, which is now
+    refused, and which ``buttervolume scheduled --auto-convert-old-patterns``
+    rewrites in the schedule.
 
 
 Schedule a job


### PR DESCRIPTION
The three sentences of `README.rst` describing the purge retention pattern each contradict the code.

- The separator is a colon, not a semicolon. Nothing has ever split a pattern on a semicolon.
- "The pattern should have at least 2 items" is false. A single specifier is allowed, and it is the way to say "keep the last two hours and delete everything older". The test suite has been purging with `2h` for a while.
- The order of the specifiers, from the shortest to the longest, is checked by the code and was documented nowhere.

The last example was worse than merely wrong: it offered `2h:2h` as the way to keep the last two hours, which is exactly the form an immediate purge refuses today. A reader following the manual got an error. The example now shows `2h`, and says where the old spelling went.

Documentation only, no code change.