### PR TITLE
Give the retention pattern its own module

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,29 +5,14 @@ subvolumes: snapshot, restore, clone, replicate. Python, Bottle, argparse.
 
 ## Finding your way around
 
+Every module opens with a docstring saying what it is for and what belongs in
+it. Read that one before adding to the module, and correct it there rather than
+describing the module here. This file holds the practices; a map of the code
+here would go stale the first time someone forgets to update it.
+
 - `README.rst` is the user manual: install, CLI usage, configuration, volume
   migration. Never duplicate it here; fix it there when it is wrong.
-- `buttervolume/plugin.py`: the Docker Volume Plugin HTTP API. Every endpoint is
-  a module-level `@route(...)` decorator there, and that list of decorators is
-  the authoritative route list. `@route` is defined there too, and is not
-  Bottle's: it decodes the request, logs it, and turns any failure into the
-  `Err` field of a 200 answer, which is the only shape a client can read.
-- `buttervolume/names.py`: what a volume name and a snapshot name are worth.
-  `volume@timestamp`, plus `@host` for the trace of a send, is read and written
-  here alone, and the validation lives here too. Pure functions: no disk, no
-  configuration, the date format arrives as an argument. The paths stay in
-  `plugin.py`, which is where the directories are configured, and a name is
-  validated there as it becomes a path.
-- `buttervolume/__init__.py`: the errors the API answers with. They sit below
-  everything so that both `names.py` and `plugin.py` can raise them.
-- `buttervolume/btrfs.py`: the subvolume operations, and `run_safe`, the guarded
-  way to call the `btrfs` command. One path escapes it and needs the same care:
-  `run_btrfs_send_receive` in `plugin.py` builds its own send and receive to
-  pipe them over SSH.
-- `buttervolume/cli.py`: the argparse commands, the scheduler thread, and the
-  waitress server that answers Docker on the unix socket.
-- `test.py`: the whole test suite, driven through `webtest` against the app.
-- `CHANGES.rst`: the changelog, one entry per user-visible change.
+- `CHANGES.rst` is the changelog, one entry per user-visible change.
 
 ## Commands
 
@@ -79,5 +64,6 @@ uv run ruff check . && uv run ruff format .
   shows. No em dashes.
 - `git add` names its files; never `git add -A`.
 - Re-read this file and `README.rst` before an important commit, and correct
-  them as soon as a sentence contradicts the code. Adding an endpoint or a
-  command that follows the conventions is not a reason to grow a list here.
+  them as soon as a sentence contradicts the code. Adding a module, an endpoint
+  or a command is not a reason to grow this file: say it in the module's
+  docstring, and here only when it changes a practice.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,10 @@ CHANGELOG
   a bare HTTP 500 on an unexpected error, which no client of this API knows how
   to read.
 
+- A purge pattern naming a unit that does not exist now says so: ``5x`` is
+  answered ``unknown unit 'x'`` instead of a bare ``'x'``, and the command line
+  refuses it without asking the server.
+
 - The chattr call enabling compression no longer goes through a shell with the
   volume path interpolated in the command line.
 - Snapshot names received through the API are now validated like volume names:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,9 +10,9 @@ CHANGELOG
   a bare HTTP 500 on an unexpected error, which no client of this API knows how
   to read.
 
-- A purge pattern naming a unit that does not exist now says so: ``5x`` is
-  answered ``unknown unit 'x'`` instead of a bare ``'x'``, and the command line
-  refuses it without asking the server.
+- A purge pattern that cannot be applied now says why. ``5x`` is answered
+  ``unknown unit 'x'`` rather than a bare ``'x'``, and a component such as
+  ``²h`` is refused as not numeric rather than reported as a failed conversion.
 
 - The chattr call enabling compression no longer goes through a shell with the
   volume path interpolated in the command line.

--- a/buttervolume/btrfs.py
+++ b/buttervolume/btrfs.py
@@ -1,3 +1,15 @@
+"""The subvolume operations, and the guarded way to call the ``btrfs`` command.
+
+Every call goes through ``run_safe``: no shell, a timeout each caller states
+for itself, and any failure raised as a typed error rather than returned as
+something the caller cannot tell apart from a result. One path escapes it and
+needs the same care: ``run_btrfs_send_receive`` in ``plugin.py`` builds its own
+send and receive to pipe them over SSH.
+
+Nothing here knows what a volume is, which is why ``BtrfsError`` lives here
+rather than with the errors the API answers with.
+"""
+
 import contextlib
 import os
 from subprocess import CalledProcessError, TimeoutExpired

--- a/buttervolume/cli.py
+++ b/buttervolume/cli.py
@@ -20,6 +20,7 @@ from requests.exceptions import ConnectionError
 from waitress import serve
 from webtest import TestApp
 
+from buttervolume import ValidationError
 from buttervolume.plugin import (
     FIELDS,
     LOGLEVEL,
@@ -30,9 +31,8 @@ from buttervolume.plugin import (
     TIMER,
     USOCKET,
     VOLUMES_PATH,
-    convert_purge_pattern,
-    validate_purge_pattern,
 )
+from buttervolume.purge import Pattern
 
 VERSION = "3.13.0"
 logging.basicConfig(level=LOGLEVEL)
@@ -134,17 +134,17 @@ def _auto_convert_old_patterns():
             if action.startswith("purge:"):
                 _, pattern = action.split(":", 1)
                 try:
-                    warning = validate_purge_pattern(pattern, allow_backward_compat=True)
-                    if warning:
-                        converted_str = convert_purge_pattern(pattern)
-                        new_action = f"purge:{converted_str}"
-                        updates.append((name, action, new_action))
-                        needs_conversion = True
-                        print(
-                            f"Found deprecated pattern for volume '{name}': '{pattern}' -> '{converted_str}'"
-                        )
-                except Exception:
-                    pass
+                    parsed = Pattern.parse(pattern)
+                except ValidationError:
+                    continue
+                if parsed.deprecated:
+                    new_action = f"purge:{parsed.text}"
+                    updates.append((name, action, new_action))
+                    needs_conversion = True
+                    print(
+                        f"Found deprecated pattern for volume '{name}': "
+                        f"'{pattern}' -> '{parsed.text}'"
+                    )
 
     if not needs_conversion:
         print("No deprecated patterns found in schedule.")
@@ -209,12 +209,12 @@ def scheduled(args):
                 if action.startswith("purge:"):
                     _, pattern = action.split(":", 1)
                     try:
-                        warning = validate_purge_pattern(pattern, allow_backward_compat=True)
-                        if warning:
-                            deprecated_patterns.append((job["Name"], action, pattern))
-                            status += " (deprecated pattern)"
-                    except Exception:
-                        pass
+                        deprecated = Pattern.parse(pattern).deprecated
+                    except ValidationError:
+                        deprecated = None
+                    if deprecated:
+                        deprecated_patterns.append((job["Name"], action, pattern))
+                        status += " (deprecated pattern)"
 
                 formatted_jobs.append(f"{job['Action']} {job['Timer']} {job['Name']} {status}")
 
@@ -423,20 +423,21 @@ def runjobs(config=SCHEDULE, test=False, schedule_log=None, timer=TIMER):
                         pattern,
                     )
 
-                    # Check for deprecated patterns and warn, but continue execution
+                    # A deprecated pattern is converted and reported, not refused
                     try:
-                        warning = validate_purge_pattern(pattern, allow_backward_compat=True)
-                        if warning:
-                            log.warning(warning)
-                            # Use the converted pattern
-                            actual_pattern = convert_purge_pattern(pattern)
-                        else:
-                            actual_pattern = pattern
-                    except Exception as e:
+                        parsed = Pattern.parse(pattern)
+                    except ValidationError as e:
                         log.error(f"Invalid purge pattern '{pattern}': {e}")
                         continue
+                    if parsed.deprecated:
+                        log.warning(
+                            "Converting deprecated pattern '%s' to '%s'. Please update your "
+                            "schedule using 'buttervolume scheduled --auto-convert-old-patterns'.",
+                            parsed.deprecated,
+                            parsed.text,
+                        )
 
-                    purge(Arg(name=[name], pattern=[actual_pattern], dryrun=False), test=test)
+                    purge(Arg(name=[name], pattern=[parsed.text], dryrun=False), test=test)
                     log.info("Finished purging")
                     schedule_log[action][name] = now
                 if action.startswith("synchronize:"):

--- a/buttervolume/cli.py
+++ b/buttervolume/cli.py
@@ -1,3 +1,17 @@
+"""The command line, the scheduler thread, and the server Docker talks to.
+
+Most commands are argparse subcommands that post to the plugin over the unix
+socket, so the command line is a client of the same API as Docker and reads the
+same answers. Three do not: ``run`` starts waitress on that socket with the
+scheduler thread beside it, ``init`` builds a BTRFS filesystem before any
+daemon exists, and ``scheduled --auto-convert-old-patterns`` rewrites
+``schedule.csv`` in place.
+
+The scheduler reads ``schedule.csv`` and runs what is due there: a snapshot, a
+replication, a synchronization or a purge. That file is the only state the
+plugin keeps outside BTRFS.
+"""
+
 import argparse
 import csv
 import json

--- a/buttervolume/plugin.py
+++ b/buttervolume/plugin.py
@@ -1,3 +1,16 @@
+"""The Docker Volume Plugin HTTP API, and where a name becomes a path.
+
+Every endpoint is a module-level ``@route(...)`` below, and that list of
+decorators is the authoritative route list. ``@route`` is defined here too, and
+is not Bottle's: it decodes the request, logs it, and turns any failure into
+the ``Err`` field of a 200 answer, which is the only shape a client can read.
+
+This is also where the directories are configured, so this is where a name
+turns into a path on disk, and where it is validated as it does. What a name is
+worth is decided in ``names.py``, what a retention pattern says in ``purge.py``;
+both are pure and know nothing of these directories.
+"""
+
 import configparser
 import csv
 import json

--- a/buttervolume/plugin.py
+++ b/buttervolume/plugin.py
@@ -32,6 +32,7 @@ from buttervolume.names import (
     validate_snapshot_name,
     validate_volume_name,
 )
+from buttervolume.purge import Pattern, compute_purges
 
 config = configparser.ConfigParser()
 config.read("/etc/buttervolume/config.ini")
@@ -619,19 +620,16 @@ def snapshots_purge(req):
     volume_name = validate_volume_name(req["Name"])
     dryrun = req.get("Dryrun", False)
 
-    # Validate pattern with strict rules (no backward compatibility for immediate purge)
-    warning = validate_purge_pattern(req["Pattern"], allow_backward_compat=False)
-    if warning:
-        raise ValidationError(f"Invalid pattern: {warning}")
-
-    # Parse pattern for compute_purges
-    pattern = parse_purge_pattern(req["Pattern"])
+    pattern = Pattern.parse(req["Pattern"])
+    # An immediate purge refuses the old duplicate spelling instead of guessing
+    if pattern.deprecated:
+        raise ValidationError(
+            f"Invalid pattern '{pattern.deprecated}'. "
+            f"Use '{pattern.text}' instead of duplicate components."
+        )
 
     snapshots = snapshots_of(volume_name, os.listdir(SNAPSHOTS_PATH))
-
-    # Compute which snapshots to purge
-    now = datetime.now()
-    purge_list = compute_purges(snapshots, pattern, now)
+    purge_list = compute_purges(snapshots, pattern, datetime.now(), DTFORMAT)
 
     for snapshot in purge_list:
         if dryrun:
@@ -642,145 +640,3 @@ def snapshots_purge(req):
             log.info(f"Deleted snapshot {snapshot}")
 
     return {"Err": ""}
-
-
-def validate_purge_pattern(pattern_str, allow_backward_compat=False):
-    """Validate purge patterns
-
-    Args:
-        pattern_str: Pattern string like "2h:1d" or "2h"
-        allow_backward_compat: If True, allow deprecated "2h:2h" patterns with warning
-
-    Returns:
-        warning_message_or_none: Warning message for deprecated patterns, None otherwise
-
-    Raises:
-        ValidationError: If pattern is invalid
-    """
-    units = {"m": 1, "h": 60, "d": 60 * 24, "w": 60 * 24 * 7, "y": 60 * 24 * 365}
-
-    try:
-        split = pattern_str.split(":")
-        assert len(split) >= 1, "Pattern must have at least 1 component"
-        assert all(p[:-1].isnumeric() for p in split), (
-            "Pattern components must be numeric with unit suffix"
-        )
-
-        # Check for deprecated duplicate patterns
-        if len(split) == 2 and split[0] == split[1]:
-            if allow_backward_compat:
-                return (
-                    f"Converting deprecated pattern '{pattern_str}' to '{split[0]}'. "
-                    f"Please update your schedule using 'buttervolume scheduled --auto-convert-old-patterns'."
-                )
-            else:
-                raise ValidationError(
-                    f"Invalid pattern '{pattern_str}'. Use '{split[0]}' instead of duplicate components."
-                )
-
-        # Check ascending order for multi-component patterns - by time values, not just units
-        if len(split) > 1:
-            time_values = [int(p[:-1]) * units[p[-1]] for p in split]
-            assert all(x < y for x, y in zip(time_values, time_values[1:])), (
-                "Time values must be in ascending order (e.g., 2h:4h:8h or 30m:2h:1d)"
-            )
-
-        return None  # Valid pattern, no warning
-
-    except (ValueError, KeyError, AssertionError) as e:
-        raise ValidationError(f"Invalid purge pattern: {pattern_str} - {str(e)}") from None
-
-
-def convert_purge_pattern(pattern_str):
-    """Convert deprecated purge patterns to new format
-
-    Args:
-        pattern_str: Pattern string like "2h:2h"
-
-    Returns:
-        converted_pattern_str: Converted pattern like "2h"
-    """
-    split = pattern_str.split(":")
-
-    # Convert "2h:2h" to "2h"
-    if len(split) == 2 and split[0] == split[1]:
-        return split[0]
-
-    # Pattern doesn't need conversion
-    return pattern_str
-
-
-def parse_purge_pattern(pattern_str):
-    """Parse purge pattern string into minutes list for compute_purges
-
-    Args:
-        pattern_str: Pattern string like "2h:1d" or "2h"
-
-    Returns:
-        list: Pattern converted to minutes, sorted in descending order
-
-    Raises:
-        ValidationError: If pattern is invalid
-    """
-    units = {"m": 1, "h": 60, "d": 60 * 24, "w": 60 * 24 * 7, "y": 60 * 24 * 365}
-
-    try:
-        split = pattern_str.split(":")
-        pattern = sorted(int(i[:-1]) * units[i[-1]] for i in split)
-        return pattern
-    except (ValueError, KeyError) as e:
-        raise ValidationError(f"Invalid purge pattern: {pattern_str} - {str(e)}") from None
-
-
-def compute_purges(snapshots, pattern, now):
-    """Return the list of snapshots to purge,
-    given a list of snapshots, a purge pattern and a now time
-    """
-    snapshots = sorted(snapshots)
-    pattern = sorted(pattern, reverse=True)
-    purge_list = []
-    max_age = pattern[0]
-    # Age of the snapshots in minutes.
-    # Example : [30, 70, 90, 150, 210, ..., 4000]
-    snapshots_age = []
-    valid_snapshots = []
-    for s in snapshots:
-        try:
-            age = now - Snapshot.parse(s).taken_at(DTFORMAT)
-        except (ValidationError, ValueError):
-            # a purge does not delete what it cannot date
-            log.info("Skipping purge of %s with invalid date format", s)
-            continue
-        snapshots_age.append(int(age.total_seconds()) / 60)
-        valid_snapshots.append(s)
-    if not valid_snapshots:
-        return purge_list
-
-    # Handle single pattern case (e.g., "2h" -> [120])
-    if len(pattern) == 1:
-        # For single pattern, delete everything older than the threshold
-        threshold = pattern[0]
-        for i, age in enumerate(snapshots_age):
-            if age > threshold:
-                purge_list.append(valid_snapshots[i])
-        return purge_list
-
-    # Handle multi-pattern case (e.g., "2h:1d:1w" -> [120, 1440, 10080])
-    # pattern = 3600:180:60
-    # age segments = [(3600, 180), (180, 60)]
-    for age_segment in [(pattern[i], pattern[i + 1]) for i, _ in enumerate(pattern[:-1])]:
-        last_timeframe = -1
-        for i, age in enumerate(snapshots_age):
-            # if the age is outside the age_segment, delete nothing.
-            # Only 70 and 90 are inside the age_segment (60, 180)
-            if age > age_segment[0] < max_age or age < age_segment[1]:
-                continue
-            # Now get the timeframe number of the snapshot.
-            # Ages 70 and 90 are in the same timeframe (70//60 == 90//60)
-            timeframe = age // age_segment[1]
-            # delete if we already had a snapshot in the same timeframe
-            # or if the snapshot is very old
-            if timeframe == last_timeframe or age > max_age:
-                purge_list.append(valid_snapshots[i])
-            last_timeframe = timeframe
-    return purge_list

--- a/buttervolume/purge.py
+++ b/buttervolume/purge.py
@@ -40,7 +40,9 @@ class Pattern:
     @classmethod
     def parse(cls, text):
         components = text.split(":")
-        if not all(c[:-1].isnumeric() for c in components):
+        # isdecimal, not isnumeric: "²".isnumeric() is True and int("²") raises,
+        # and a pattern nobody can apply must not leave here as a ValueError
+        if not all(c[:-1].isdecimal() for c in components):
             raise ValidationError(
                 f"Invalid purge pattern: {text} - "
                 "Pattern components must be numeric with unit suffix"

--- a/buttervolume/purge.py
+++ b/buttervolume/purge.py
@@ -1,0 +1,111 @@
+"""What a snapshot retention pattern says, and which snapshots it condemns.
+
+A pattern is written ``4h:1d:2w``: keep everything from the last four hours,
+then one snapshot every four hours up to a day, then one a day up to two
+weeks, then nothing. A pattern of a single specifier, ``2h``, keeps the last
+two hours and deletes the rest.
+
+Older versions accepted ``2h:2h`` for that last one. Such a pattern is read
+back here as the ``2h`` it means, and the original spelling is kept in
+``deprecated`` so the caller can decide what to do with it: an immediate purge
+refuses it, the scheduler converts it and says so.
+
+Nothing here touches the disk and nothing here reads the configuration: the
+date format arrives as an argument, as it does for a snapshot name.
+"""
+
+import logging
+from dataclasses import dataclass
+
+from buttervolume import ValidationError
+from buttervolume.names import Snapshot
+
+log = logging.getLogger()
+
+UNITS = {"m": 1, "h": 60, "d": 60 * 24, "w": 60 * 24 * 7, "y": 60 * 24 * 365}
+
+
+@dataclass(frozen=True)
+class Pattern:
+    """A retention pattern, read: its durations in minutes and its spelling.
+
+    It is only built by parse(), so `minutes` is always strictly ascending and
+    a caller never has to wonder whether the pattern it holds was checked.
+    """
+
+    minutes: tuple[int, ...]
+    text: str
+    deprecated: str | None = None
+
+    @classmethod
+    def parse(cls, text):
+        components = text.split(":")
+        if not all(c[:-1].isnumeric() for c in components):
+            raise ValidationError(
+                f"Invalid purge pattern: {text} - "
+                "Pattern components must be numeric with unit suffix"
+            )
+        for c in components:
+            if c[-1] not in UNITS:
+                raise ValidationError(f"Invalid purge pattern: {text} - unknown unit '{c[-1]}'")
+        minutes = tuple(int(c[:-1]) * UNITS[c[-1]] for c in components)
+
+        if len(components) == 2 and components[0] == components[1]:
+            return cls(minutes[:1], components[0], deprecated=text)
+
+        if not all(x < y for x, y in zip(minutes, minutes[1:])):
+            raise ValidationError(
+                f"Invalid purge pattern: {text} - "
+                "Time values must be in ascending order (e.g., 2h:4h:8h or 30m:2h:1d)"
+            )
+        return cls(minutes, text)
+
+    def __str__(self):
+        return self.text
+
+
+def compute_purges(snapshots, pattern, now, dtformat):
+    """Return the list of snapshots this pattern condemns, at this moment."""
+    snapshots = sorted(snapshots)
+    ages = list(reversed(pattern.minutes))
+    purge_list = []
+    max_age = ages[0]
+    # Age of the snapshots in minutes.
+    # Example : [30, 70, 90, 150, 210, ..., 4000]
+    snapshots_age = []
+    valid_snapshots = []
+    for s in snapshots:
+        try:
+            age = now - Snapshot.parse(s).taken_at(dtformat)
+        except (ValidationError, ValueError):
+            # a purge does not delete what it cannot date
+            log.info("Skipping purge of %s with invalid date format", s)
+            continue
+        snapshots_age.append(int(age.total_seconds()) / 60)
+        valid_snapshots.append(s)
+    if not valid_snapshots:
+        return purge_list
+
+    # A single specifier ("2h" -> [120]) deletes everything past the threshold
+    if len(ages) == 1:
+        return [s for s, age in zip(valid_snapshots, snapshots_age) if age > ages[0]]
+
+    # Several specifiers ("2h:1d:1w" -> [10080, 1440, 120]) keep one snapshot
+    # per timeframe inside each segment.
+    # age segments = [(10080, 1440), (1440, 120)]
+    for age_segment in [(ages[i], ages[i + 1]) for i, _ in enumerate(ages[:-1])]:
+        last_timeframe = -1
+        for i, age in enumerate(snapshots_age):
+            # if the age is outside the age_segment, delete nothing.
+            # Only 70 and 90 are inside the age_segment (60, 180)
+            if age > age_segment[0] < max_age or age < age_segment[1]:
+                continue
+            # Now get the timeframe number of the snapshot.
+            # Ages 70 and 90 are in the same timeframe (70//60 == 90//60)
+            timeframe = age // age_segment[1]
+            # delete if we already had a snapshot in the same timeframe
+            # or if the snapshot is very old
+            if timeframe == last_timeframe or age > max_age:
+                purge_list.append(valid_snapshots[i])
+            last_timeframe = timeframe
+    return purge_list

--- a/test.py
+++ b/test.py
@@ -1194,7 +1194,7 @@ class TestPurgePattern(unittest.TestCase):
         self.assertEqual(pattern.deprecated, "2h:2h")
 
     def test_a_pattern_nobody_could_apply_is_refused(self):
-        for text in ("", "2h:", "60m:plop:3000m", "5x", "4h:2h", "2h:120m", "2h:2h:4h"):
+        for text in ("", "2h:", "60m:plop:3000m", "5x", "²h", "4h:2h", "2h:120m", "2h:2h:4h"):
             with self.assertRaises(ValidationError):
                 Pattern.parse(text)
 

--- a/test.py
+++ b/test.py
@@ -30,8 +30,8 @@ from buttervolume.plugin import (
     SNAPSHOTS_PATH,
     TEST_REMOTE_PATH,
     VOLUMES_PATH,
-    compute_purges,
 )
+from buttervolume.purge import Pattern, compute_purges
 
 # check that the target dir is btrfs
 SCHEDULE = plugin.SCHEDULE = tempfile.mkstemp()[1]
@@ -831,6 +831,29 @@ class TestCase(unittest.TestCase):
         )
         self.assertIn("Invalid pattern '2h:2h'. Use '2h' instead", jsonloads(resp.body)["Err"])
 
+        # check the order of the components is checked, shortest first
+        resp = self.app.post(
+            "/VolumeDriver.Snapshots.Purge",
+            json.dumps({"Name": name, "Pattern": "4h:2h"}),
+        )
+        self.assertEqual(
+            jsonloads(resp.body),
+            {
+                "Err": "Invalid purge pattern: 4h:2h - Time values must be in ascending order"
+                " (e.g., 2h:4h:8h or 30m:2h:1d)"
+            },
+        )
+
+        # check we have an error with an unknown unit
+        resp = self.app.post(
+            "/VolumeDriver.Snapshots.Purge",
+            json.dumps({"Name": name, "Pattern": "5x"}),
+        )
+        self.assertEqual(
+            jsonloads(resp.body),
+            {"Err": "Invalid purge pattern: 5x - unknown unit 'x'"},
+        )
+
         # check we have an error with a non numeric pattern
         resp = self.app.post(
             "/VolumeDriver.Snapshots.Purge",
@@ -902,9 +925,7 @@ class TestCase(unittest.TestCase):
             "foobar@" + (now - timedelta(hours=h, minutes=30)).strftime(DTFORMAT)
             for h in range(5000)
         ]
-        purge_list = compute_purges(  # 1d:1w:4w:1y
-            snapshots, [60 * 24, 60 * 24 * 7, 60 * 24 * 7 * 4, 60 * 24 * 365], now
-        )
+        purge_list = compute_purges(snapshots, Pattern.parse("1d:1w:4w:1y"), now, DTFORMAT)
         not_purged = set(snapshots) - set(purge_list)
         self.assertEqual(len(not_purged), 40)
 
@@ -912,9 +933,7 @@ class TestCase(unittest.TestCase):
         now = datetime.now()
         snapshots = ["foobar@" + (now - timedelta(hours=h)).strftime(DTFORMAT) for h in range(3000)]
         for now in [now + timedelta(hours=h) for h in range(3000)]:
-            purge_list = compute_purges(  # 1d:1w:4w:1y
-                snapshots, [60 * 24, 60 * 24 * 7, 60 * 24 * 7 * 4, 60 * 24 * 365], now
-            )
+            purge_list = compute_purges(snapshots, Pattern.parse("1d:1w:4w:1y"), now, DTFORMAT)
             snapshots = sorted(set(snapshots) - set(purge_list))
         self.assertEqual(len(snapshots), 4)
 
@@ -1157,6 +1176,27 @@ class TestNames(unittest.TestCase):
         self.assertEqual(str(already_sent[-1].without_host()), "www@t2")
         # and the trace this send will leave behind
         self.assertEqual(str(Snapshot.parse("www@t3").sent_to("node2")), "www@t3@node2")
+
+
+class TestPurgePattern(unittest.TestCase):
+    """The retention pattern, read without touching a filesystem"""
+
+    def test_a_pattern_is_read_as_the_durations_it_names(self):
+        self.assertEqual(Pattern.parse("2h").minutes, (120,))
+        self.assertEqual(Pattern.parse("30m:2h:1d:1w:1y").minutes, (30, 120, 1440, 10080, 525600))
+        self.assertEqual(str(Pattern.parse("4h:1d")), "4h:1d")
+        self.assertIsNone(Pattern.parse("4h:1d").deprecated)
+
+    def test_the_old_way_of_writing_a_single_duration_is_read_as_that_duration(self):
+        pattern = Pattern.parse("2h:2h")
+        self.assertEqual(pattern.minutes, (120,))
+        self.assertEqual(pattern.text, "2h")
+        self.assertEqual(pattern.deprecated, "2h:2h")
+
+    def test_a_pattern_nobody_could_apply_is_refused(self):
+        for text in ("", "2h:", "60m:plop:3000m", "5x", "4h:2h", "2h:120m", "2h:2h:4h"):
+            with self.assertRaises(ValidationError):
+                Pattern.parse(text)
 
 
 class TemporaryDirectory(tempfile.TemporaryDirectory):

--- a/test.py
+++ b/test.py
@@ -1,3 +1,11 @@
+"""The whole test suite, driven through ``webtest`` against the app.
+
+Most tests post to the plugin the way Docker does, then check what came back
+and what the snapshots directory holds, so they need a real BTRFS filesystem:
+``./test_local.sh`` sets one up. The ones that need no filesystem at all sit in
+their own classes at the bottom and read names and patterns directly.
+"""
+
 import json
 import logging
 import os


### PR DESCRIPTION
Four functions at the bottom of `plugin.py` read the purge retention pattern (`4h:1d:2w`), splitting the same string three times, with two private copies of the table saying how many minutes a day or a year is worth.

The two that checked a pattern did not agree on what a pattern is:

| pattern | `validate_purge_pattern` | `parse_purge_pattern` |
|---|---|---|
| `5x`    | accepts | `Invalid purge pattern: 5x - 'x'` |
| `4h:2h` | refuses | accepts `[120, 240]` |
| `2h:2h` | refuses | accepts `[120, 120]` |

The reading now happens once, in `Pattern.parse`, and what it returns is always usable: the durations are strictly ascending, so nothing downstream has to wonder whether the pattern it holds was checked.

**What changes for a user.** Two error messages, both on patterns that were already refused. `5x` was answered with a bare `'x'`, a `KeyError` copied into the response, and is now answered `unknown unit 'x'`. `²h` was answered with a failed integer conversion and is now refused as not numeric. What is accepted does not change: 3630 patterns, ASCII and not, were run through the old pair of functions and through the new one, and the endpoint accepts exactly the same set.

The command line refuses a few of them locally now rather than posting them to a server that would refuse them anyway. `buttervolume purge` itself still posts the pattern as typed; the local reading happens where the scheduler classifies what is written in `schedule.csv`.

**The deprecated spelling.** `2h:2h` used to be the way to say "keep the last two hours". It is now read back as the `2h` it means, with the original kept beside it in `deprecated`. What to do with it is not the reader's business: an immediate purge refuses it and says which spelling to use, the scheduler converts it and logs that it did. That decision used to be a boolean argument to the reader, which returned a warning to one caller and raised at another for the same input.

One thing to know about this shape: `Pattern.parse` now accepts a spelling that strict validation used to raise on, so refusing it is a caller's `if pattern.deprecated: raise`, one line a future endpoint could forget. The trade is that no caller can hold a pattern that was never checked.

**Tests.** Two rejections nothing had ever tested are now tested at the API: a pattern running from the longest to the shortest, and one naming a unit that does not exist. A `TestPurgePattern` class reads patterns without touching a filesystem, as `TestNames` does. The two `compute_purges` tests name their pattern (`Pattern.parse("1d:1w:4w:1y")`) instead of spelling out the four numbers with a comment saying what they mean.

`./test_local.sh`: 34 passed, 4 skipped (the SSH ones, as before).

**Left alone.** `_auto_convert_old_patterns` rewrites `schedule.csv` behind an `input()` and has no test. Its parsing is now one call and is covered; the CSV rewriting is another subject.

`AGENTS.md` is deliberately not extended with a paragraph for the new module: #91 removes that map and moves it into the module docstrings, which is where `purge.py` already explains itself.
