### PR TITLE
Let each module explain itself, and keep AGENTS.md to the practices

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,29 +5,14 @@ subvolumes: snapshot, restore, clone, replicate. Python, Bottle, argparse.
 
 ## Finding your way around
 
+Every module opens with a docstring saying what it is for and what belongs in
+it. Read that one before adding to the module, and correct it there rather than
+describing the module here. This file holds the practices; a map of the code
+here would go stale the first time someone forgets to update it.
+
 - `README.rst` is the user manual: install, CLI usage, configuration, volume
   migration. Never duplicate it here; fix it there when it is wrong.
-- `buttervolume/plugin.py`: the Docker Volume Plugin HTTP API. Every endpoint is
-  a module-level `@route(...)` decorator there, and that list of decorators is
-  the authoritative route list. `@route` is defined there too, and is not
-  Bottle's: it decodes the request, logs it, and turns any failure into the
-  `Err` field of a 200 answer, which is the only shape a client can read.
-- `buttervolume/names.py`: what a volume name and a snapshot name are worth.
-  `volume@timestamp`, plus `@host` for the trace of a send, is read and written
-  here alone, and the validation lives here too. Pure functions: no disk, no
-  configuration, the date format arrives as an argument. The paths stay in
-  `plugin.py`, which is where the directories are configured, and a name is
-  validated there as it becomes a path.
-- `buttervolume/__init__.py`: the errors the API answers with. They sit below
-  everything so that both `names.py` and `plugin.py` can raise them.
-- `buttervolume/btrfs.py`: the subvolume operations, and `run_safe`, the guarded
-  way to call the `btrfs` command. One path escapes it and needs the same care:
-  `run_btrfs_send_receive` in `plugin.py` builds its own send and receive to
-  pipe them over SSH.
-- `buttervolume/cli.py`: the argparse commands, the scheduler thread, and the
-  waitress server that answers Docker on the unix socket.
-- `test.py`: the whole test suite, driven through `webtest` against the app.
-- `CHANGES.rst`: the changelog, one entry per user-visible change.
+- `CHANGES.rst` is the changelog, one entry per user-visible change.
 
 ## Commands
 
@@ -79,5 +64,6 @@ uv run ruff check . && uv run ruff format .
   shows. No em dashes.
 - `git add` names its files; never `git add -A`.
 - Re-read this file and `README.rst` before an important commit, and correct
-  them as soon as a sentence contradicts the code. Adding an endpoint or a
-  command that follows the conventions is not a reason to grow a list here.
+  them as soon as a sentence contradicts the code. Adding a module, an endpoint
+  or a command is not a reason to grow this file: say it in the module's
+  docstring, and here only when it changes a practice.

--- a/buttervolume/btrfs.py
+++ b/buttervolume/btrfs.py
@@ -1,3 +1,15 @@
+"""The subvolume operations, and the guarded way to call the ``btrfs`` command.
+
+Every call goes through ``run_safe``: no shell, a timeout each caller states
+for itself, and any failure raised as a typed error rather than returned as
+something the caller cannot tell apart from a result. One path escapes it and
+needs the same care: ``run_btrfs_send_receive`` in ``plugin.py`` builds its own
+send and receive to pipe them over SSH.
+
+Nothing here knows what a volume is, which is why ``BtrfsError`` lives here
+rather than with the errors the API answers with.
+"""
+
 import contextlib
 import os
 from subprocess import CalledProcessError, TimeoutExpired

--- a/buttervolume/cli.py
+++ b/buttervolume/cli.py
@@ -1,9 +1,11 @@
 """The command line, the scheduler thread, and the server Docker talks to.
 
-The commands are argparse subcommands that post to the plugin over the unix
+Most commands are argparse subcommands that post to the plugin over the unix
 socket, so the command line is a client of the same API as Docker and reads the
-same answers. ``run`` is the exception: it starts waitress on that socket, and
-the scheduler thread beside it.
+same answers. Three do not: ``run`` starts waitress on that socket with the
+scheduler thread beside it, ``init`` builds a BTRFS filesystem before any
+daemon exists, and ``scheduled --auto-convert-old-patterns`` rewrites
+``schedule.csv`` in place.
 
 The scheduler reads ``schedule.csv`` and runs what is due there: a snapshot, a
 replication, a synchronization or a purge. That file is the only state the

--- a/buttervolume/cli.py
+++ b/buttervolume/cli.py
@@ -1,3 +1,15 @@
+"""The command line, the scheduler thread, and the server Docker talks to.
+
+The commands are argparse subcommands that post to the plugin over the unix
+socket, so the command line is a client of the same API as Docker and reads the
+same answers. ``run`` is the exception: it starts waitress on that socket, and
+the scheduler thread beside it.
+
+The scheduler reads ``schedule.csv`` and runs what is due there: a snapshot, a
+replication, a synchronization or a purge. That file is the only state the
+plugin keeps outside BTRFS.
+"""
+
 import argparse
 import csv
 import json

--- a/buttervolume/plugin.py
+++ b/buttervolume/plugin.py
@@ -1,3 +1,16 @@
+"""The Docker Volume Plugin HTTP API, and where a name becomes a path.
+
+Every endpoint is a module-level ``@route(...)`` below, and that list of
+decorators is the authoritative route list. ``@route`` is defined here too, and
+is not Bottle's: it decodes the request, logs it, and turns any failure into
+the ``Err`` field of a 200 answer, which is the only shape a client can read.
+
+This is also where the directories are configured, so this is where a name
+turns into a path on disk, and where it is validated as it does. What a name is
+worth is decided in ``names.py``, what a retention pattern says in ``purge.py``;
+both are pure and know nothing of these directories.
+"""
+
 import configparser
 import csv
 import json

--- a/test.py
+++ b/test.py
@@ -1,3 +1,11 @@
+"""The whole test suite, driven through ``webtest`` against the app.
+
+Most tests post to the plugin the way Docker does, then check what came back
+and what the snapshots directory holds, so they need a real BTRFS filesystem:
+``./test_local.sh`` sets one up. The ones that need no filesystem at all sit in
+their own classes at the bottom and read names and patterns directly.
+"""
+
 import json
 import logging
 import os


### PR DESCRIPTION
The map of the code in `AGENTS.md` had grown to a paragraph per module, and every new module added one more. That list is the wrong place for it twice over: it sits far from what it describes, so it goes stale the first time someone forgets to update it, and it is read by whoever opens `AGENTS.md` rather than by whoever opens the module.

Each paragraph moves into the docstring of the module it was about, where it is in front of the reader who needs it and in front of the reader about to contradict it. `plugin.py`, `btrfs.py`, `cli.py` and `test.py` had no docstring at all and now say what they are for and what belongs in them; `names.py`, `purge.py` and `__init__.py` already had one.

`AGENTS.md` keeps what belongs to the repository rather than to one file: the practices, the commands, and where the user manual and the changelog are. It goes from 88 lines to 69, and stops growing with the code. The rule about not growing it now says where a new module gets described instead.

Nothing changes in the code itself, only what sits above the imports. `./test_local.sh`: 34 passed, 4 skipped, as before.

Stacked on #90, which is where `purge.py` comes from. Review that one first; this branch shows only its own commit once #90 is merged.
