### PR TITLE
Say out loud a scheduled action nobody knows

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,11 @@ CHANGELOG
 3.13 (unreleased)
 *****************
 
+- The scheduler now reports a line of ``schedule.csv`` whose action it does
+  not know, instead of skipping it silently at every run. The guard meant to
+  do this could never fire, so a misspelled ``replicat:host`` looked exactly
+  like a replication that ran on time.
+
 - Every endpoint now goes through a single decorator that decodes the request,
   logs it and turns any failure into the ``Err`` field of a 200 answer. Six
   routes, among them the scheduling ones and the snapshot send, used to answer

--- a/buttervolume/cli.py
+++ b/buttervolume/cli.py
@@ -387,9 +387,6 @@ def runjobs(config=SCHEDULE, test=False, schedule_log=None, timer=TIMER):
                 last = schedule_log[action][name]
                 if now < last + timedelta(minutes=int(timer)):
                     continue
-                if action not in schedule_log:
-                    log.warning("Skipping invalid action %s", action)
-                    continue
                 # choose and run the right action
                 if action == "snapshot":
                     log.info("Starting scheduled snapshot of %s", name)
@@ -399,7 +396,7 @@ def runjobs(config=SCHEDULE, test=False, schedule_log=None, timer=TIMER):
                         continue
                     log.info("Successfully snapshotted to %s", snap)
                     schedule_log[action][name] = now
-                if action.startswith("replicate:"):
+                elif action.startswith("replicate:"):
                     if name in ReplicationInProgress:
                         log.warning(f"Replication of {name} already in progress, skipping.")
                         continue
@@ -429,7 +426,7 @@ def runjobs(config=SCHEDULE, test=False, schedule_log=None, timer=TIMER):
                                 )
                     finally:
                         ReplicationInProgress.remove(name)
-                if action.startswith("purge:"):
+                elif action.startswith("purge:"):
                     _, pattern = action.split(":", 1)
                     log.info(
                         "Starting scheduled purge of %s with pattern %s",
@@ -454,7 +451,7 @@ def runjobs(config=SCHEDULE, test=False, schedule_log=None, timer=TIMER):
                     purge(Arg(name=[name], pattern=[parsed.text], dryrun=False), test=test)
                     log.info("Finished purging")
                     schedule_log[action][name] = now
-                if action.startswith("synchronize:"):
+                elif action.startswith("synchronize:"):
                     log.info("Starting scheduled synchronization of %s", name)
                     hosts = action.split(":")[1].split(",")
                     # do a snapshot to save state before pulling data
@@ -463,6 +460,8 @@ def runjobs(config=SCHEDULE, test=False, schedule_log=None, timer=TIMER):
                     sync(Arg(volumes=[name], hosts=hosts), test=test)
                     log.debug("End of %s synchronization from %s", name, hosts)
                     schedule_log[action][name] = now
+                else:
+                    log.warning("Skipping the unknown action %s of %s", action, name)
             except CalledProcessError as e:
                 log.error(
                     "Error processing scheduler action file %s "

--- a/test.py
+++ b/test.py
@@ -1001,6 +1001,30 @@ class TestCase(unittest.TestCase):
             json.dumps({"Name": name, "Action": "purge:2h:2h", "Timer": 0}),
         )
 
+    def test_an_unknown_scheduled_action_is_reported(self):
+        """A misspelled action in the schedule must be said out loud
+
+        It can only come from a hand-edited file, and until now the scheduler
+        skipped it silently at every run, so a volume nobody replicated looked
+        exactly like a volume replicated every hour.
+        """
+        name = PREFIX_TEST_VOLUME + uuid.uuid4().hex
+        self.create_a_volume_with_a_file(name)
+        with open(SCHEDULE, "w") as f:
+            f.write(f"{name},replicat:localhost,60,True\n")
+        nb_snaps = len(os.listdir(SNAPSHOTS_PATH))
+
+        with self.assertLogs(level=logging.WARNING) as log_capture:
+            runjobs(config=SCHEDULE, test=True)
+
+        self.assertTrue(
+            any(
+                f"Skipping the unknown action replicat:localhost of {name}" in msg
+                for msg in log_capture.output
+            )
+        )
+        self.assertEqual(len(os.listdir(SNAPSHOTS_PATH)), nb_snaps)
+
     @unittest.skipIf(
         os.environ.get("BUTTERVOLUME_LOCAL_TEST"), "SSH not available in local test mode"
     )


### PR DESCRIPTION
The scheduler had a guard meant to report a line of `schedule.csv` whose
action it does not know:

```python
schedule_log.setdefault(action, {})
...
if action not in schedule_log:
    log.warning("Skipping invalid action %s", action)
```

The `setdefault` a few lines above creates the very key the condition tests
for, so the condition is always false and the warning could never be printed.
A line such as `replicat:localhost` therefore passed the due check, matched
none of the four known actions, and fell out of the loop having done nothing
and said nothing, at every run, forever. A volume nobody replicated looked
exactly like a volume replicated every hour.

The four actions now form a single chain with a final `else`, which is where
the warning belongs: an action matching none of them is reported by name.

Such a line can only come from a hand-edited file today, and the test writes
one directly for that reason. The endpoint still accepts a misspelled action
and writes it into the file; refusing it there is a separate subject.