### PR TITLE
Refuse a schedule that nobody could run

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,15 @@ CHANGELOG
   do this could never fire, so a misspelled ``replicat:host`` looked exactly
   like a replication that ran on time.
 
+- Scheduling a job that nobody could run is now refused instead of answered
+  with a success. A misspelled action such as ``replicat:host``, an unreadable
+  retention pattern, an invalid volume name or a timer that is not a number of
+  minutes used to be accepted, and the command reported nothing while either
+  writing a line the scheduler would silently ignore, or writing nothing at
+  all. Unscheduling, pausing or resuming a job that is not in the schedule is
+  refused for the same reason. A line already written stays possible to pause
+  and to delete, whatever it says.
+
 - Every endpoint now goes through a single decorator that decodes the request,
   logs it and turns any failure into the ``Err`` field of a 200 answer. Six
   routes, among them the scheduling ones and the snapshot send, used to answer

--- a/buttervolume/plugin.py
+++ b/buttervolume/plugin.py
@@ -7,8 +7,9 @@ the ``Err`` field of a 200 answer, which is the only shape a client can read.
 
 This is also where the directories are configured, so this is where a name
 turns into a path on disk, and where it is validated as it does. What a name is
-worth is decided in ``names.py``, what a retention pattern says in ``purge.py``;
-both are pure and know nothing of these directories.
+worth is decided in ``names.py``, what a retention pattern says in ``purge.py``,
+what a scheduled action asks for in ``schedule.py``; all three are pure and know
+nothing of these directories.
 """
 
 import configparser
@@ -46,6 +47,7 @@ from buttervolume.names import (
     validate_volume_name,
 )
 from buttervolume.purge import Pattern, compute_purges
+from buttervolume.schedule import Job
 
 config = configparser.ConfigParser()
 config.read("/etc/buttervolume/config.ini")
@@ -517,19 +519,35 @@ def schedule(req):
         schedule = {
             (line["Name"], line["Action"]): line for line in csv.DictReader(f, fieldnames=FIELDS)
         }
-        if timer == "pause" and (name, action) in schedule:
+
+    if timer in ("pause", "resume", "0", "delete"):
+        # These name a line that is already written, whatever it says: a job
+        # this endpoint once accepted must stay possible to pause and to
+        # delete. Only the line named is looked at, never the others.
+        if (name, action) not in schedule:
+            raise ValidationError(f"No '{action}' of '{name}' is scheduled")
+        if timer == "pause":
             schedule[(name, action)]["Active"] = False
-        elif timer == "resume" and (name, action) in schedule:
+        elif timer == "resume":
             schedule[(name, action)]["Active"] = True
-        elif timer in ("0", "delete") and (name, action) in schedule:
+        else:
             del schedule[(name, action)]
-        elif timer.isnumeric() and timer not in ("0", "delete"):
-            schedule[(name, action)] = {
-                "Name": name,
-                "Action": action,
-                "Timer": timer,
-                "Active": True,
-            }
+    elif timer.isdecimal() and int(timer) > 0:
+        # isdecimal, not isnumeric: "²".isnumeric() is True and int("²")
+        # raises, and the scheduler reads this timer back with int()
+        validate_volume_name(name)
+        Job.parse(action)
+        schedule[(name, action)] = {
+            "Name": name,
+            "Action": action,
+            "Timer": timer,
+            "Active": True,
+        }
+    else:
+        raise ValidationError(
+            f"Invalid timer '{timer}'. It must be a number of minutes, or "
+            "'pause', 'resume', or '0' or 'delete' to unschedule"
+        )
 
     with open(SCHEDULE, "w") as f:
         csv.DictWriter(f, fieldnames=FIELDS).writerows(schedule.values())

--- a/buttervolume/purge.py
+++ b/buttervolume/purge.py
@@ -8,7 +8,8 @@ two hours and deletes the rest.
 Older versions accepted ``2h:2h`` for that last one. Such a pattern is read
 back here as the ``2h`` it means, and the original spelling is kept in
 ``deprecated`` so the caller can decide what to do with it: an immediate purge
-refuses it, the scheduler converts it and says so.
+refuses it, a schedule still accepts it as it is written, and the scheduler
+converts it and says so at every run.
 
 Nothing here touches the disk and nothing here reads the configuration: the
 date format arrives as an argument, as it does for a snapshot name.

--- a/buttervolume/schedule.py
+++ b/buttervolume/schedule.py
@@ -1,0 +1,69 @@
+"""What a scheduled job asks for, read from the way it is written.
+
+A line of ``schedule.csv`` names its job in a single string: ``snapshot``,
+``replicate:node2``, ``purge:4h:1d:1w``, ``synchronize:node2,node3``. Reading
+that string is all this module does. It touches no disk and runs nothing: what
+a host is worth is decided in ``names.py``, what a retention pattern says in
+``purge.py``, and this module asks them.
+
+A job keeps the action exactly as the schedule spells it, because that string
+is how the scheduler remembers when the job last ran.
+
+An action nobody could run leaves here as a ``ValidationError``, so no caller
+has to decide what an unknown verb means.
+"""
+
+from dataclasses import dataclass
+
+from buttervolume import ValidationError
+from buttervolume.names import validate_hostname
+from buttervolume.purge import Pattern
+
+
+@dataclass(frozen=True)
+class Job:
+    """A scheduled job, and the action it was read from."""
+
+    text: str
+
+    @classmethod
+    def parse(cls, action):
+        verb, _, rest = action.partition(":")
+        if verb == "snapshot" and not rest:
+            return Snapshot(action)
+        if verb == "replicate":
+            return Replicate(action, validate_hostname(rest))
+        if verb == "purge":
+            return Purge(action, Pattern.parse(rest))
+        if verb == "synchronize":
+            return Synchronize(action, tuple(validate_hostname(h) for h in rest.split(",")))
+        raise ValidationError(
+            f"Invalid action '{action}'. It must be 'snapshot', 'replicate:<host>', "
+            "'purge:<pattern>' or 'synchronize:<host>[,<host>]'"
+        )
+
+
+@dataclass(frozen=True)
+class Snapshot(Job):
+    """Snapshot the volume."""
+
+
+@dataclass(frozen=True)
+class Replicate(Job):
+    """Snapshot the volume, then send that snapshot to this host."""
+
+    host: str
+
+
+@dataclass(frozen=True)
+class Purge(Job):
+    """Delete the snapshots this retention pattern does not keep."""
+
+    pattern: Pattern
+
+
+@dataclass(frozen=True)
+class Synchronize(Job):
+    """Snapshot the volume, then pull it back from these hosts."""
+
+    hosts: tuple

--- a/buttervolume/schedule.py
+++ b/buttervolume/schedule.py
@@ -28,8 +28,9 @@ class Job:
 
     @classmethod
     def parse(cls, action):
-        verb, _, rest = action.partition(":")
-        if verb == "snapshot" and not rest:
+        verb, colon, rest = action.partition(":")
+        # the colon, not the rest: "snapshot:" names no job either
+        if verb == "snapshot" and not colon:
             return Snapshot(action)
         if verb == "replicate":
             return Replicate(action, validate_hostname(rest))

--- a/test.py
+++ b/test.py
@@ -1291,6 +1291,7 @@ class TestScheduledJob(unittest.TestCase):
         for action in (
             "",
             "replicat:node2",
+            "snapshot:",
             "snapshot:node2",
             "snapshots",
             "replicate",

--- a/test.py
+++ b/test.py
@@ -25,7 +25,7 @@ from unittest.mock import MagicMock, patch
 
 from webtest import TestApp
 
-from buttervolume import ValidationError, btrfs, cli, plugin
+from buttervolume import ValidationError, btrfs, cli, plugin, schedule
 from buttervolume.cli import init_btrfs, runjobs
 from buttervolume.names import (
     Snapshot,
@@ -40,6 +40,7 @@ from buttervolume.plugin import (
     VOLUMES_PATH,
 )
 from buttervolume.purge import Pattern, compute_purges
+from buttervolume.schedule import Job
 
 # check that the target dir is btrfs
 SCHEDULE = plugin.SCHEDULE = tempfile.mkstemp()[1]
@@ -588,11 +589,6 @@ class TestCase(unittest.TestCase):
         resp = self.app.get("/VolumeDriver.Schedule.List")
         schedule = json.loads(resp.body.decode())["Schedule"]
         self.assertEqual(len(schedule), 0)
-        # unschedule
-        self.app.post(
-            "/VolumeDriver.Schedule",
-            json.dumps({"Name": name, "Action": "snapshot", "Timer": 0}),
-        )
 
     @unittest.skipIf(
         os.environ.get("BUTTERVOLUME_LOCAL_TEST"), "SSH not available in local test mode"
@@ -1025,6 +1021,46 @@ class TestCase(unittest.TestCase):
         )
         self.assertEqual(len(os.listdir(SNAPSHOTS_PATH)), nb_snaps)
 
+    def test_a_schedule_nobody_could_run_is_refused(self):
+        """The endpoint is where a schedule is written, so it is where it is judged"""
+        name = PREFIX_TEST_VOLUME + uuid.uuid4().hex
+        for req, expected in (
+            ({"Name": name, "Action": "replicat:localhost", "Timer": 60}, "Invalid action"),
+            ({"Name": name, "Action": "purge:5x", "Timer": 60}, "unknown unit"),
+            ({"Name": name, "Action": "snapshot", "Timer": "demain"}, "Invalid timer"),
+            ({"Name": name, "Action": "snapshot", "Timer": "²"}, "Invalid timer"),
+            ({"Name": name + "/../..", "Action": "snapshot", "Timer": 60}, "Invalid characters"),
+        ):
+            resp = self.app.post("/VolumeDriver.Schedule", json.dumps(req))
+            self.assertIn(expected, jsonloads(resp.body)["Err"])
+        # nothing of all this was written
+        resp = self.app.get("/VolumeDriver.Schedule.List")
+        self.assertEqual(jsonloads(resp.body)["Schedule"], [])
+
+    def test_unscheduling_a_job_nobody_scheduled_is_refused(self):
+        """Saying yes to that is how a typo passes for a job that is running"""
+        name = PREFIX_TEST_VOLUME + uuid.uuid4().hex
+        for timer in ("0", "delete", "pause", "resume"):
+            resp = self.app.post(
+                "/VolumeDriver.Schedule",
+                json.dumps({"Name": name, "Action": "snapshot", "Timer": timer}),
+            )
+            self.assertIn("is scheduled", jsonloads(resp.body)["Err"])
+
+    def test_a_job_written_before_this_validation_can_still_be_deleted(self):
+        """An action the endpoint now refuses may already sit in the file"""
+        name = PREFIX_TEST_VOLUME + uuid.uuid4().hex
+        with open(SCHEDULE, "w") as f:
+            f.write(f"{name},replicat:localhost,60,True\n")
+
+        resp = self.app.post(
+            "/VolumeDriver.Schedule",
+            json.dumps({"Name": name, "Action": "replicat:localhost", "Timer": 0}),
+        )
+        self.assertEqual(jsonloads(resp.body)["Err"], "")
+        resp = self.app.get("/VolumeDriver.Schedule.List")
+        self.assertEqual(jsonloads(resp.body)["Schedule"], [])
+
     @unittest.skipIf(
         os.environ.get("BUTTERVOLUME_LOCAL_TEST"), "SSH not available in local test mode"
     )
@@ -1229,6 +1265,42 @@ class TestPurgePattern(unittest.TestCase):
         for text in ("", "2h:", "60m:plop:3000m", "5x", "²h", "4h:2h", "2h:120m", "2h:2h:4h"):
             with self.assertRaises(ValidationError):
                 Pattern.parse(text)
+
+
+class TestScheduledJob(unittest.TestCase):
+    """What a scheduled action asks for, read without touching a filesystem"""
+
+    def test_an_action_is_read_as_the_job_it_asks_for(self):
+        self.assertEqual(Job.parse("snapshot"), schedule.Snapshot("snapshot"))
+        self.assertEqual(
+            Job.parse("replicate:node2"), schedule.Replicate("replicate:node2", "node2")
+        )
+        self.assertEqual(
+            Job.parse("synchronize:node2,node3"),
+            schedule.Synchronize("synchronize:node2,node3", ("node2", "node3")),
+        )
+        purge_job = Job.parse("purge:4h:1d")
+        self.assertEqual(purge_job.pattern, Pattern.parse("4h:1d"))
+
+    def test_a_job_remembers_how_the_schedule_spells_it(self):
+        """The scheduler keys its own log on that text, deprecated spelling included"""
+        self.assertEqual(Job.parse("purge:2h:2h").text, "purge:2h:2h")
+        self.assertEqual(Job.parse("purge:2h:2h").pattern.text, "2h")
+
+    def test_an_action_nobody_could_run_is_refused(self):
+        for action in (
+            "",
+            "replicat:node2",
+            "snapshot:node2",
+            "snapshots",
+            "replicate",
+            "replicate:no host",
+            "purge:5x",
+            "purge:",
+            "synchronize:node2,",
+        ):
+            with self.assertRaises(ValidationError):
+                Job.parse(action)
 
 
 class TemporaryDirectory(tempfile.TemporaryDirectory):


### PR DESCRIPTION
`/VolumeDriver.Schedule` is the only place the API writes `schedule.csv`, and
it judged nothing it was given.

The timer went through a chain of `if`/`elif` ending on `timer.isnumeric()`.
A timer of `demain` matched no branch: the file was rewritten unchanged and
the handler answered `{"Err": ""}`. The command exited 0, and the volume the
user believed snapshotted every hour was snapshotted never.

```
buttervolume schedule snapshot demain myvolume   # said yes, scheduled nothing
buttervolume schedule replicat:node2 60 myvolume # typo accepted, then ignored
```

The action was never read at all, so the typo above landed in the file, where
the scheduler skipped it just as quietly. `isnumeric` was also the footgun
already removed from the retention patterns: `"²".isnumeric()` is true, and
`int("²")` raises in the scheduler at every run.

A new pure module, `buttervolume/schedule.py`, says what an action asks for.
It sits next to `names.py`, which says what a name is worth, and `purge.py`,
which says what a retention pattern means, and it asks them both. The endpoint
now asks it before writing anything, and validates the volume name the way
every other endpoint does.

Two things this deliberately does not do:

- It judges only the incoming request. The other lines of the file are copied
  over untouched, so one line written before this change cannot make every
  other scheduling operation fail.
- It exempts `pause`, `resume`, `0` and `delete` from reading the action.
  These name a line that already exists, and a schedule this endpoint once
  accepted must stay possible to undo. A test writes such a line by hand and
  deletes it through the endpoint.

Unscheduling, pausing or resuming a job that is not in the schedule is now
refused, for the same reason as the rest: it used to answer success without
doing anything.