### PR TITLE
Let the scheduler read a job instead of cutting up strings

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,12 @@ CHANGELOG
   do this could never fire, so a misspelled ``replicat:host`` looked exactly
   like a replication that ran on time.
 
+- A scheduled replication or synchronization naming a host that Buttervolume
+  refuses, such as an SSH alias with an underscore, now stops and says so at
+  every run. Such a line could be written by an older version, and it never
+  replicated anything, because the send refused that host too; but it went on
+  snapshotting the volume every period while reporting a success.
+
 - Scheduling a job that nobody could run is now refused instead of answered
   with a success. A misspelled action such as ``replicat:host``, an unreadable
   retention pattern, an invalid volume name or a timer that is not a number of

--- a/buttervolume/cli.py
+++ b/buttervolume/cli.py
@@ -8,8 +8,9 @@ daemon exists, and ``scheduled --auto-convert-old-patterns`` rewrites
 ``schedule.csv`` in place.
 
 The scheduler reads ``schedule.csv`` and runs what is due there: a snapshot, a
-replication, a synchronization or a purge. That file is the only state the
-plugin keeps outside BTRFS.
+replication, a synchronization or a purge. What each line asks for is read in
+``schedule.py``, so the loop below only has to run it. That file is the only
+state the plugin keeps outside BTRFS.
 """
 
 import argparse
@@ -47,6 +48,7 @@ from buttervolume.plugin import (
     VOLUMES_PATH,
 )
 from buttervolume.purge import Pattern
+from buttervolume.schedule import Job, Purge, Replicate, Snapshot
 
 VERSION = "3.13.0"
 logging.basicConfig(level=LOGLEVEL)
@@ -380,6 +382,11 @@ def runjobs(config=SCHEDULE, test=False, schedule_log=None, timer=TIMER):
                 if not enabled:
                     log.info(f"{action} of {name} is disabled")
                     continue
+                try:
+                    job = Job.parse(action)
+                except ValidationError as e:
+                    log.warning("Skipping the unknown action %s of %s: %s", action, name, e)
+                    continue
                 now = datetime.now()
                 # just starting, we consider beeing late on snapshots
                 schedule_log.setdefault(action, {})
@@ -388,7 +395,7 @@ def runjobs(config=SCHEDULE, test=False, schedule_log=None, timer=TIMER):
                 if now < last + timedelta(minutes=int(timer)):
                     continue
                 # choose and run the right action
-                if action == "snapshot":
+                if isinstance(job, Snapshot):
                     log.info("Starting scheduled snapshot of %s", name)
                     snap = snapshot(Arg(name=[name]), test=test)
                     if not snap:
@@ -396,11 +403,10 @@ def runjobs(config=SCHEDULE, test=False, schedule_log=None, timer=TIMER):
                         continue
                     log.info("Successfully snapshotted to %s", snap)
                     schedule_log[action][name] = now
-                elif action.startswith("replicate:"):
+                elif isinstance(job, Replicate):
                     if name in ReplicationInProgress:
                         log.warning(f"Replication of {name} already in progress, skipping.")
                         continue
-                    _, host = action.split(":")
                     log.info("Starting scheduled replication of %s", name)
                     snap = None
                     try:
@@ -410,7 +416,7 @@ def runjobs(config=SCHEDULE, test=False, schedule_log=None, timer=TIMER):
                             log.info("Could not snapshot %s", name)
                             continue
                         log.info("Successfully snapshotted to %s", snap)
-                        send(Arg(snapshot=[snap], host=[host]), test=test)
+                        send(Arg(snapshot=[snap], host=[job.host]), test=test)
                         log.info("Successfully replicated %s to %s", name, snap)
                         schedule_log[action][name] = now
                     except Exception as e:
@@ -426,20 +432,14 @@ def runjobs(config=SCHEDULE, test=False, schedule_log=None, timer=TIMER):
                                 )
                     finally:
                         ReplicationInProgress.remove(name)
-                elif action.startswith("purge:"):
-                    _, pattern = action.split(":", 1)
+                elif isinstance(job, Purge):
+                    parsed = job.pattern
                     log.info(
                         "Starting scheduled purge of %s with pattern %s",
                         name,
-                        pattern,
+                        parsed.deprecated or parsed.text,
                     )
-
                     # A deprecated pattern is converted and reported, not refused
-                    try:
-                        parsed = Pattern.parse(pattern)
-                    except ValidationError as e:
-                        log.error(f"Invalid purge pattern '{pattern}': {e}")
-                        continue
                     if parsed.deprecated:
                         log.warning(
                             "Converting deprecated pattern '%s' to '%s'. Please update your "
@@ -451,17 +451,15 @@ def runjobs(config=SCHEDULE, test=False, schedule_log=None, timer=TIMER):
                     purge(Arg(name=[name], pattern=[parsed.text], dryrun=False), test=test)
                     log.info("Finished purging")
                     schedule_log[action][name] = now
-                elif action.startswith("synchronize:"):
+                else:  # a Synchronize, the only job left
                     log.info("Starting scheduled synchronization of %s", name)
-                    hosts = action.split(":")[1].split(",")
+                    hosts = list(job.hosts)
                     # do a snapshot to save state before pulling data
                     snap = snapshot(Arg(name=[name]), test=test)
                     log.debug("Successfully snapshotted to %s", snap)
                     sync(Arg(volumes=[name], hosts=hosts), test=test)
                     log.debug("End of %s synchronization from %s", name, hosts)
                     schedule_log[action][name] = now
-                else:
-                    log.warning("Skipping the unknown action %s of %s", action, name)
             except CalledProcessError as e:
                 log.error(
                     "Error processing scheduler action file %s "

--- a/test.py
+++ b/test.py
@@ -1061,6 +1061,25 @@ class TestCase(unittest.TestCase):
         resp = self.app.get("/VolumeDriver.Schedule.List")
         self.assertEqual(jsonloads(resp.body)["Schedule"], [])
 
+    def test_a_host_the_schedule_can_no_longer_name_stops_the_job(self):
+        """A replication to a host that is refused now stops, and says so
+
+        Such a line could be written by an older version. It never replicated
+        anything, because the send refused the host too, but it did keep
+        snapshotting the volume every period while logging a success.
+        """
+        name = PREFIX_TEST_VOLUME + uuid.uuid4().hex
+        self.create_a_volume_with_a_file(name)
+        with open(SCHEDULE, "w") as f:
+            f.write(f"{name},replicate:backup_host,60,True\n")
+        nb_snaps = len(os.listdir(SNAPSHOTS_PATH))
+
+        with self.assertLogs(level=logging.WARNING) as log_capture:
+            runjobs(config=SCHEDULE, test=True)
+
+        self.assertTrue(any("replicate:backup_host" in msg for msg in log_capture.output))
+        self.assertEqual(len(os.listdir(SNAPSHOTS_PATH)), nb_snaps)
+
     @unittest.skipIf(
         os.environ.get("BUTTERVOLUME_LOCAL_TEST"), "SSH not available in local test mode"
     )


### PR DESCRIPTION
The scheduler loop cut the action string apart four times, each in its own
way, and had to trust each piece on the spot: the host of a replication came
from `action.split(":")` that would have raised on a second colon, the pattern
of a purge was parsed in the middle of the branch that used it, and the list
of hosts of a synchronization was split twice in one line.

Reading the line is now done once, before anything runs, by the same module
the endpoint asks in #93. What comes back is one of four jobs carrying what it
needs, so each branch only has to run its job. The action matching none of the
four never reaches the branches at all: it is reported where the line is read.

The parts that could have drifted are left exactly as they were on purpose:

- The scheduler log stays keyed on the action as the file spells it, deprecated
  spelling included, which is what the tests inject.
- The deprecated retention pattern is still converted and reported with the
  same sentence, not refused.
- The last-run mark is still set where it was set before, which is not the same
  place in all four branches.
- The two broad `except` blocks stay inside the loop, so one unusable line
  still does not stop the following ones.

One behaviour does change, and it is not an accident of the rewrite. A line
naming a host that `validate_hostname` refuses, such as the SSH alias
`replicate:backup_host`, was accepted by the old split and is refused by the
reading. That line never replicated anything, because the send refused the
host too, but it did keep snapshotting the volume every period and logging a
replication that had not happened. It now stops and says so at every run. The
changelog says it and a test pins it.

Tested with `./test_local.sh` (42 passed, 4 skipped) and with the Docker suite
`./test.sh`, which runs the four tests the local run skips: 46 passed,
`test_schedule_replicate`, `test_schedule_synchronization`, `test_send` and
`test_synchronization` among them.
