### PR TITLE
Stop reporting a replication whose send failed as a success

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,14 @@ CHANGELOG
   do this could never fire, so a misspelled ``replicat:host`` looked exactly
   like a replication that ran on time.
 
+- A scheduled replication whose send failed is no longer reported as a
+  success. The send answered with an error, the client logged it and returned
+  a value nobody read, and the scheduler logged "Successfully replicated"
+  right after, kept the snapshot it had taken for the occasion, and considered
+  the job done until the next period. It now takes the same road as a
+  replication that raised: the failure is reported and the snapshot removed.
+  A purge and a synchronization that failed are reported as well.
+
 - A scheduled replication or synchronization naming a host that Buttervolume
   refuses, such as an SSH alias with an underscore, now stops and says so at
   every run. Such a line could be written by an older version, and it never

--- a/buttervolume/cli.py
+++ b/buttervolume/cli.py
@@ -35,7 +35,7 @@ from requests.exceptions import ConnectionError
 from waitress import serve
 from webtest import TestApp
 
-from buttervolume import ValidationError
+from buttervolume import ReplicationError, ValidationError
 from buttervolume.plugin import (
     FIELDS,
     LOGLEVEL,
@@ -301,10 +301,9 @@ def send(args, test=False):
             f"http+unix://{urllib.parse.quote_plus(USOCKET)}{urlpath}",
             json.dumps(param),
         )
-    res = get_from(resp, "")
-    if res:
-        print(res)
-    return res
+    # the endpoint answers with an empty payload, so the only thing to report
+    # is whether the job happened: get_from already logged the error.
+    return get_from(resp, "") is not False
 
 
 def sync(args, test=False):
@@ -318,10 +317,9 @@ def sync(args, test=False):
             f"http+unix://{urllib.parse.quote_plus(USOCKET)}{urlpath}",
             json.dumps(param),
         )
-    res = get_from(resp, "")
-    if res:
-        print(res)
-    return res
+    # the endpoint answers with an empty payload, so the only thing to report
+    # is whether the job happened: get_from already logged the error.
+    return get_from(resp, "") is not False
 
 
 def remove(args, test=False):
@@ -347,10 +345,9 @@ def purge(args, test=False):
             f"http+unix://{urllib.parse.quote_plus(USOCKET)}{urlpath}",
             json.dumps(param),
         )
-    res = get_from(resp, "")
-    if res:
-        print(res)
-    return res
+    # the endpoint answers with an empty payload, so the only thing to report
+    # is whether the job happened: get_from already logged the error.
+    return get_from(resp, "") is not False
 
 
 class Arg:
@@ -416,7 +413,11 @@ def runjobs(config=SCHEDULE, test=False, schedule_log=None, timer=TIMER):
                             log.info("Could not snapshot %s", name)
                             continue
                         log.info("Successfully snapshotted to %s", snap)
-                        send(Arg(snapshot=[snap], host=[job.host]), test=test)
+                        if not send(Arg(snapshot=[snap], host=[job.host]), test=test):
+                            # the same road as an exception: the error is
+                            # already logged, and the snapshot taken for this
+                            # replication has no reason to stay
+                            raise ReplicationError(f"Could not send {snap} to {job.host}")
                         log.info("Successfully replicated %s to %s", name, snap)
                         schedule_log[action][name] = now
                     except Exception as e:
@@ -448,17 +449,24 @@ def runjobs(config=SCHEDULE, test=False, schedule_log=None, timer=TIMER):
                             parsed.text,
                         )
 
-                    purge(Arg(name=[name], pattern=[parsed.text], dryrun=False), test=test)
-                    log.info("Finished purging")
+                    if purge(Arg(name=[name], pattern=[parsed.text], dryrun=False), test=test):
+                        log.info("Finished purging")
+                    else:
+                        log.warning("Could not purge the snapshots of %s", name)
                     schedule_log[action][name] = now
                 else:  # a Synchronize, the only job left
                     log.info("Starting scheduled synchronization of %s", name)
                     hosts = list(job.hosts)
                     # do a snapshot to save state before pulling data
                     snap = snapshot(Arg(name=[name]), test=test)
+                    if not snap:
+                        log.info("Could not snapshot %s", name)
+                        continue
                     log.debug("Successfully snapshotted to %s", snap)
-                    sync(Arg(volumes=[name], hosts=hosts), test=test)
-                    log.debug("End of %s synchronization from %s", name, hosts)
+                    if sync(Arg(volumes=[name], hosts=hosts), test=test):
+                        log.debug("End of %s synchronization from %s", name, hosts)
+                    else:
+                        log.warning("Could not synchronize %s from %s", name, hosts)
                     schedule_log[action][name] = now
             except CalledProcessError as e:
                 log.error(

--- a/test.py
+++ b/test.py
@@ -171,9 +171,14 @@ class TestCase(unittest.TestCase):
             "/VolumeDriver.Schedule",
             json.dumps({"Name": name, "Action": "replicate:localhost", "Timer": 1}),
         )
+
         # simulate a long-running replication
+        def slow_send(*args, **kwargs):
+            time.sleep(2)
+            return True
+
         with patch("buttervolume.cli.send") as mock_send:
-            mock_send.side_effect = lambda *args, **kwargs: time.sleep(2)
+            mock_send.side_effect = slow_send
             # run the scheduler in a separate thread
             t = threading.Thread(target=runjobs, args=(SCHEDULE, True))
             t.start()
@@ -266,6 +271,26 @@ class TestCase(unittest.TestCase):
             "/VolumeDriver.Schedule",
             json.dumps({"Name": name, "Action": "replicate:localhost", "Timer": 0}),
         )
+
+    def test_a_replication_that_failed_is_not_reported_as_a_success(self):
+        """A send answering an error is a failed replication, not a done one"""
+        name = PREFIX_TEST_VOLUME + uuid.uuid4().hex
+        self.create_a_volume_with_a_file(name)
+        self.app.post(
+            "/VolumeDriver.Schedule",
+            json.dumps({"Name": name, "Action": "replicate:localhost", "Timer": 1}),
+        )
+        with patch("buttervolume.cli.send") as mock_send:
+            # what the client answers when the endpoint fills the Err field
+            mock_send.return_value = False
+            with self.assertLogs(level=logging.INFO) as log_capture:
+                runjobs(SCHEDULE, True)
+
+        self.assertFalse(any("Successfully replicated" in msg for msg in log_capture.output))
+        self.assertTrue(any("Replication failed" in msg for msg in log_capture.output))
+        # the snapshot taken for that replication was removed, like any other
+        # failed replication
+        self.assertEqual([s for s in os.listdir(SNAPSHOTS_PATH) if s.startswith(name + "@")], [])
 
     def test_send_error_reports_send_stderr(self):
         """A failed send/receive reports the error of the send side too"""


### PR DESCRIPTION
The scheduler replicated like this:

```python
send(Arg(snapshot=[snap], host=[host]), test=test)
log.info("Successfully replicated %s to %s", name, snap)
schedule_log[action][name] = now
```

When the send answered with a filled `Err` field, the client logged that error
and returned `False`, which nobody read. So the line below announced a success,
the snapshot taken for that replication stayed on disk, and the job counted as
done until the next period. A node that had received nothing for a week looked
exactly like a node replicated every hour, and the only trace was one error
line lost among the successes.

A failed send now takes the road a raised replication already took since #80:
the failure is reported and the snapshot taken for it removed.

The reason nobody read that value is worth fixing where it lives. `send`,
`sync` and `purge` all end on an endpoint that answers an empty payload, and
all three returned that empty payload, which is falsy whether the job worked
or not. They now answer whether it worked, the way `rm` already did. The
scheduler no longer claims a purge or a synchronization it could not do
either; those two keep their period, since their failure is reported and
retrying every minute would only repeat it.

`test_replication_lock` mocked `send` with a function returning nothing, which
now means failure; the mock returns a success, which is what it was standing
for.

Tested with `./test_local.sh` (43 passed, 4 skipped) and with the Docker suite
`./test.sh`, which runs the send and synchronization tests the local run skips:
47 passed.

