### PR TITLE
Read the schedule file in one place instead of five

### DIFF
--- a/buttervolume/cli.py
+++ b/buttervolume/cli.py
@@ -49,10 +49,12 @@ from buttervolume.plugin import (
 )
 from buttervolume.purge import Pattern
 from buttervolume.schedule import (
+    Entry,
     Job,
     Purge,
     Replicate,
     Snapshot,
+    read_rows,
     read_schedule,
     write_schedule,
 )
@@ -356,8 +358,11 @@ def runjobs(config=SCHEDULE, test=False, schedule_log=None, timer=TIMER):
         return
     name = action = timer = ""
     # run each action in the schedule if time is elapsed since the last one
-    for entry in read_schedule(config):
+    for row in read_rows(config):
         try:
+            # read here rather than in one go above: a line nobody can read
+            # must not stop the lines that follow it
+            entry = Entry.parse(row)
             name, action, timer = entry.name, entry.action, entry.timer
             if not entry.enabled:
                 log.info(f"{action} of {name} is disabled")

--- a/buttervolume/cli.py
+++ b/buttervolume/cli.py
@@ -7,14 +7,13 @@ scheduler thread beside it, ``init`` builds a BTRFS filesystem before any
 daemon exists, and ``scheduled --auto-convert-old-patterns`` rewrites
 ``schedule.csv`` in place.
 
-The scheduler reads ``schedule.csv`` and runs what is due there: a snapshot, a
-replication, a synchronization or a purge. What each line asks for is read in
-``schedule.py``, so the loop below only has to run it. That file is the only
-state the plugin keeps outside BTRFS.
+The scheduler runs what is due in ``schedule.csv``: a snapshot, a replication,
+a synchronization or a purge. Reading that file, and reading what each of its
+lines asks for, is ``schedule.py``'s business, so the loop below only has to
+run it. That file is the only state the plugin keeps outside BTRFS.
 """
 
 import argparse
-import csv
 import json
 import logging
 import os
@@ -25,6 +24,8 @@ import sys
 import threading
 import traceback
 import urllib.parse
+from contextlib import suppress
+from dataclasses import replace
 from datetime import datetime, timedelta
 from os.path import exists
 from subprocess import CalledProcessError
@@ -37,7 +38,6 @@ from webtest import TestApp
 
 from buttervolume import ReplicationError, ValidationError
 from buttervolume.plugin import (
-    FIELDS,
     LOGLEVEL,
     SCHEDULE,
     SCHEDULE_DISABLED,
@@ -48,7 +48,14 @@ from buttervolume.plugin import (
     VOLUMES_PATH,
 )
 from buttervolume.purge import Pattern
-from buttervolume.schedule import Job, Purge, Replicate, Snapshot
+from buttervolume.schedule import (
+    Job,
+    Purge,
+    Replicate,
+    Snapshot,
+    read_schedule,
+    write_schedule,
+)
 
 VERSION = "3.13.0"
 logging.basicConfig(level=LOGLEVEL)
@@ -139,35 +146,30 @@ def _auto_convert_old_patterns():
         print(f"Schedule file not found: {config}")
         return False
 
-    # Read current schedule
-    updates = []
-    needs_conversion = False
+    entries = read_schedule(config)
+    converted = []
+    for entry in entries:
+        # An action nobody can read is left exactly as it is: this command
+        # converts patterns, it does not clean up the file.
+        job = None
+        with suppress(ValidationError):
+            job = Job.parse(entry.action)
+        if isinstance(job, Purge) and job.pattern.deprecated:
+            converted.append(replace(entry, action=f"purge:{job.pattern.text}"))
+            print(
+                f"Found deprecated pattern for volume '{entry.name}': "
+                f"'{job.pattern.deprecated}' -> '{job.pattern.text}'"
+            )
+        else:
+            converted.append(entry)
 
-    with open(config) as f:
-        for line in csv.DictReader(f, fieldnames=FIELDS):
-            name, action, timer, enabled = line.values()
-
-            if action.startswith("purge:"):
-                _, pattern = action.split(":", 1)
-                try:
-                    parsed = Pattern.parse(pattern)
-                except ValidationError:
-                    continue
-                if parsed.deprecated:
-                    new_action = f"purge:{parsed.text}"
-                    updates.append((name, action, new_action))
-                    needs_conversion = True
-                    print(
-                        f"Found deprecated pattern for volume '{name}': "
-                        f"'{pattern}' -> '{parsed.text}'"
-                    )
-
-    if not needs_conversion:
+    count = sum(1 for old, new in zip(entries, converted) if old != new)
+    if not count:
         print("No deprecated patterns found in schedule.")
         return True
 
     # Ask for confirmation
-    print(f"\nFound {len(updates)} deprecated pattern(s). Convert them? (y/N): ", end="")
+    print(f"\nFound {count} deprecated pattern(s). Convert them? (y/N): ", end="")
     response = input().strip().lower()
 
     if response not in ("y", "yes"):
@@ -180,26 +182,9 @@ def _auto_convert_old_patterns():
     shutil.copy2(config, backup_file)
     print(f"Created backup: {backup_file}")
 
-    # Read and update the file
-    lines = []
-    with open(config) as f:
-        for line in csv.DictReader(f, fieldnames=FIELDS):
-            name, action, timer, enabled = line.values()
+    write_schedule(config, converted)
 
-            # Check if this line needs updating
-            for update_name, old_action, new_action in updates:
-                if name == update_name and action == old_action:
-                    action = new_action
-                    break
-
-            lines.append([name, action, timer, enabled])
-
-    # Write updated file
-    with open(config, "w", newline="") as f:
-        writer = csv.writer(f)
-        writer.writerows(lines)
-
-    print(f"Successfully converted {len(updates)} pattern(s).")
+    print(f"Successfully converted {count} pattern(s).")
     print("Updated schedule file. The scheduler will use the new patterns on next run.")
     return True
 
@@ -371,125 +356,123 @@ def runjobs(config=SCHEDULE, test=False, schedule_log=None, timer=TIMER):
         return
     name = action = timer = ""
     # run each action in the schedule if time is elapsed since the last one
-    with open(config) as f:
-        for line in csv.DictReader(f, fieldnames=FIELDS):
+    for entry in read_schedule(config):
+        try:
+            name, action, timer = entry.name, entry.action, entry.timer
+            if not entry.enabled:
+                log.info(f"{action} of {name} is disabled")
+                continue
             try:
-                name, action, timer, enabled = line.values()
-                enabled = enabled != "False"
-                if not enabled:
-                    log.info(f"{action} of {name} is disabled")
+                job = Job.parse(action)
+            except ValidationError as e:
+                log.warning("Skipping the unknown action %s of %s: %s", action, name, e)
+                continue
+            now = datetime.now()
+            # just starting, we consider beeing late on snapshots
+            schedule_log.setdefault(action, {})
+            schedule_log[action].setdefault(name, now - timedelta(1))
+            last = schedule_log[action][name]
+            if now < last + timedelta(minutes=int(timer)):
+                continue
+            # choose and run the right action
+            if isinstance(job, Snapshot):
+                log.info("Starting scheduled snapshot of %s", name)
+                snap = snapshot(Arg(name=[name]), test=test)
+                if not snap:
+                    log.info("Could not snapshot %s", name)
                     continue
+                log.info("Successfully snapshotted to %s", snap)
+                schedule_log[action][name] = now
+            elif isinstance(job, Replicate):
+                if name in ReplicationInProgress:
+                    log.warning(f"Replication of {name} already in progress, skipping.")
+                    continue
+                log.info("Starting scheduled replication of %s", name)
+                snap = None
                 try:
-                    job = Job.parse(action)
-                except ValidationError as e:
-                    log.warning("Skipping the unknown action %s of %s: %s", action, name, e)
-                    continue
-                now = datetime.now()
-                # just starting, we consider beeing late on snapshots
-                schedule_log.setdefault(action, {})
-                schedule_log[action].setdefault(name, now - timedelta(1))
-                last = schedule_log[action][name]
-                if now < last + timedelta(minutes=int(timer)):
-                    continue
-                # choose and run the right action
-                if isinstance(job, Snapshot):
-                    log.info("Starting scheduled snapshot of %s", name)
+                    ReplicationInProgress.add(name)
                     snap = snapshot(Arg(name=[name]), test=test)
                     if not snap:
                         log.info("Could not snapshot %s", name)
                         continue
                     log.info("Successfully snapshotted to %s", snap)
+                    if not send(Arg(snapshot=[snap], host=[job.host]), test=test):
+                        # the same road as an exception: the error is
+                        # already logged, and the snapshot taken for this
+                        # replication has no reason to stay
+                        raise ReplicationError(f"Could not send {snap} to {job.host}")
+                    log.info("Successfully replicated %s to %s", name, snap)
                     schedule_log[action][name] = now
-                elif isinstance(job, Replicate):
-                    if name in ReplicationInProgress:
-                        log.warning(f"Replication of {name} already in progress, skipping.")
-                        continue
-                    log.info("Starting scheduled replication of %s", name)
-                    snap = None
-                    try:
-                        ReplicationInProgress.add(name)
-                        snap = snapshot(Arg(name=[name]), test=test)
-                        if not snap:
-                            log.info("Could not snapshot %s", name)
-                            continue
-                        log.info("Successfully snapshotted to %s", snap)
-                        if not send(Arg(snapshot=[snap], host=[job.host]), test=test):
-                            # the same road as an exception: the error is
-                            # already logged, and the snapshot taken for this
-                            # replication has no reason to stay
-                            raise ReplicationError(f"Could not send {snap} to {job.host}")
-                        log.info("Successfully replicated %s to %s", name, snap)
-                        schedule_log[action][name] = now
-                    except Exception as e:
-                        log.warning("Replication failed: %s", e)
-                        # remove snapshot that was created for the failed replication
-                        if snap:
-                            if remove(Arg(name=[snap]), test=test):
-                                log.info("Removed snapshot %s for failed replication", snap)
-                            else:
-                                log.warning(
-                                    "Could not remove snapshot %s of the failed replication",
-                                    snap,
-                                )
-                    finally:
-                        ReplicationInProgress.remove(name)
-                elif isinstance(job, Purge):
-                    parsed = job.pattern
-                    log.info(
-                        "Starting scheduled purge of %s with pattern %s",
-                        name,
-                        parsed.deprecated or parsed.text,
+                except Exception as e:
+                    log.warning("Replication failed: %s", e)
+                    # remove snapshot that was created for the failed replication
+                    if snap:
+                        if remove(Arg(name=[snap]), test=test):
+                            log.info("Removed snapshot %s for failed replication", snap)
+                        else:
+                            log.warning(
+                                "Could not remove snapshot %s of the failed replication",
+                                snap,
+                            )
+                finally:
+                    ReplicationInProgress.remove(name)
+            elif isinstance(job, Purge):
+                parsed = job.pattern
+                log.info(
+                    "Starting scheduled purge of %s with pattern %s",
+                    name,
+                    parsed.deprecated or parsed.text,
+                )
+                # A deprecated pattern is converted and reported, not refused
+                if parsed.deprecated:
+                    log.warning(
+                        "Converting deprecated pattern '%s' to '%s'. Please update your "
+                        "schedule using 'buttervolume scheduled --auto-convert-old-patterns'.",
+                        parsed.deprecated,
+                        parsed.text,
                     )
-                    # A deprecated pattern is converted and reported, not refused
-                    if parsed.deprecated:
-                        log.warning(
-                            "Converting deprecated pattern '%s' to '%s'. Please update your "
-                            "schedule using 'buttervolume scheduled --auto-convert-old-patterns'.",
-                            parsed.deprecated,
-                            parsed.text,
-                        )
 
-                    if purge(Arg(name=[name], pattern=[parsed.text], dryrun=False), test=test):
-                        log.info("Finished purging")
-                    else:
-                        log.warning("Could not purge the snapshots of %s", name)
-                    schedule_log[action][name] = now
-                else:  # a Synchronize, the only job left
-                    log.info("Starting scheduled synchronization of %s", name)
-                    hosts = list(job.hosts)
-                    # do a snapshot to save state before pulling data
-                    snap = snapshot(Arg(name=[name]), test=test)
-                    if not snap:
-                        log.info("Could not snapshot %s", name)
-                        continue
-                    log.debug("Successfully snapshotted to %s", snap)
-                    if sync(Arg(volumes=[name], hosts=hosts), test=test):
-                        log.debug("End of %s synchronization from %s", name, hosts)
-                    else:
-                        log.warning("Could not synchronize %s from %s", name, hosts)
-                    schedule_log[action][name] = now
-            except CalledProcessError as e:
-                log.error(
-                    "Error processing scheduler action file %s "
-                    "name=%s, action=%s, timer=%s, "
-                    "exception=%s, stdout=%s, stderr=%s",
-                    config,
-                    name,
-                    action,
-                    timer,
-                    str(e),
-                    e.stdout,
-                    e.stderr,
-                )
-            except Exception as e:
-                log.error(
-                    "Error processing scheduler action file %s name=%s, action=%s, timer=%s\n%s",
-                    config,
-                    name,
-                    action,
-                    timer,
-                    str(e),
-                )
+                if purge(Arg(name=[name], pattern=[parsed.text], dryrun=False), test=test):
+                    log.info("Finished purging")
+                else:
+                    log.warning("Could not purge the snapshots of %s", name)
+                schedule_log[action][name] = now
+            else:  # a Synchronize, the only job left
+                log.info("Starting scheduled synchronization of %s", name)
+                hosts = list(job.hosts)
+                # do a snapshot to save state before pulling data
+                snap = snapshot(Arg(name=[name]), test=test)
+                if not snap:
+                    log.info("Could not snapshot %s", name)
+                    continue
+                log.debug("Successfully snapshotted to %s", snap)
+                if sync(Arg(volumes=[name], hosts=hosts), test=test):
+                    log.debug("End of %s synchronization from %s", name, hosts)
+                else:
+                    log.warning("Could not synchronize %s from %s", name, hosts)
+                schedule_log[action][name] = now
+        except CalledProcessError as e:
+            log.error(
+                "Error processing scheduler action file %s "
+                "name=%s, action=%s, timer=%s, "
+                "exception=%s, stdout=%s, stderr=%s",
+                config,
+                name,
+                action,
+                timer,
+                str(e),
+                e.stdout,
+                e.stderr,
+            )
+        except Exception as e:
+            log.error(
+                "Error processing scheduler action file %s name=%s, action=%s, timer=%s\n%s",
+                config,
+                name,
+                action,
+                timer,
+                str(e),
+            )
 
 
 def scheduler(event, config=SCHEDULE, test=False, timer=TIMER):

--- a/buttervolume/plugin.py
+++ b/buttervolume/plugin.py
@@ -8,18 +8,18 @@ the ``Err`` field of a 200 answer, which is the only shape a client can read.
 This is also where the directories are configured, so this is where a name
 turns into a path on disk, and where it is validated as it does. What a name is
 worth is decided in ``names.py``, what a retention pattern says in ``purge.py``,
-what a scheduled action asks for in ``schedule.py``; all three are pure and know
-nothing of these directories.
+what a scheduled action asks for in ``schedule.py``; none of them knows these
+directories, and the schedule file is read and written there rather than here.
 """
 
 import configparser
-import csv
 import json
 import logging
 import os
 import subprocess
 import tempfile
 import time
+from dataclasses import replace
 from datetime import datetime
 from functools import wraps
 from os.path import basename, dirname, join
@@ -47,7 +47,7 @@ from buttervolume.names import (
     validate_volume_name,
 )
 from buttervolume.purge import Pattern, compute_purges
-from buttervolume.schedule import Job
+from buttervolume.schedule import Entry, Job, read_schedule, write_schedule
 
 config = configparser.ConfigParser()
 config.read("/etc/buttervolume/config.ini")
@@ -64,7 +64,6 @@ SNAPSHOTS_PATH = getconfig(config, "SNAPSHOTS_PATH", "/var/lib/buttervolume/snap
 TEST_REMOTE_PATH = getconfig(config, "TEST_REMOTE_PATH", "/var/lib/buttervolume/received/")
 SCHEDULE = getconfig(config, "SCHEDULE", "/etc/buttervolume/schedule.csv")
 SCHEDULE_DISABLED = f"{SCHEDULE}.disabled"
-FIELDS = ["Name", "Action", "Timer", "Active"]
 # Support both old and new plugin names for backward compatibility
 DRIVERNAME = getconfig(config, "DRIVERNAME", "ccomb/buttervolume:latest")
 LEGACY_DRIVERNAME = "anybox/buttervolume:latest"
@@ -515,10 +514,7 @@ def schedule(req):
         os.makedirs(dirname(SCHEDULE), exist_ok=True)
         with open(SCHEDULE, "w") as f:
             f.write("")
-    with open(SCHEDULE) as f:
-        schedule = {
-            (line["Name"], line["Action"]): line for line in csv.DictReader(f, fieldnames=FIELDS)
-        }
+    schedule = {(entry.name, entry.action): entry for entry in read_schedule(SCHEDULE)}
 
     if timer in ("pause", "resume", "0", "delete"):
         # These name a line that is already written, whatever it says: a job
@@ -527,9 +523,9 @@ def schedule(req):
         if (name, action) not in schedule:
             raise ValidationError(f"No '{action}' of '{name}' is scheduled")
         if timer == "pause":
-            schedule[(name, action)]["Active"] = False
+            schedule[(name, action)] = replace(schedule[(name, action)], active="False")
         elif timer == "resume":
-            schedule[(name, action)]["Active"] = True
+            schedule[(name, action)] = replace(schedule[(name, action)], active="True")
         else:
             del schedule[(name, action)]
     elif timer.isdecimal() and int(timer) > 0:
@@ -537,20 +533,14 @@ def schedule(req):
         # raises, and the scheduler reads this timer back with int()
         validate_volume_name(name)
         Job.parse(action)
-        schedule[(name, action)] = {
-            "Name": name,
-            "Action": action,
-            "Timer": timer,
-            "Active": True,
-        }
+        schedule[(name, action)] = Entry(name, action, timer, "True")
     else:
         raise ValidationError(
             f"Invalid timer '{timer}'. It must be a number of minutes, or "
             "'pause', 'resume', or '0' or 'delete' to unschedule"
         )
 
-    with open(SCHEDULE, "w") as f:
-        csv.DictWriter(f, fieldnames=FIELDS).writerows(schedule.values())
+    write_schedule(SCHEDULE, schedule.values())
     return {"Err": ""}
 
 
@@ -561,8 +551,7 @@ def scheduled(_):
         return {"Err": "Schedule is globally paused"}
     schedule = []
     if os.path.exists(SCHEDULE):
-        with open(SCHEDULE) as f:
-            schedule = list(csv.DictReader(f, fieldnames=FIELDS))
+        schedule = [entry.fields for entry in read_schedule(SCHEDULE)]
     return {"Err": "", "Schedule": schedule}
 
 

--- a/buttervolume/schedule.py
+++ b/buttervolume/schedule.py
@@ -1,23 +1,35 @@
-"""What a scheduled job asks for, read from the way it is written.
+"""What the schedule file says: its lines, and the job each one names.
 
 A line of ``schedule.csv`` names its job in a single string: ``snapshot``,
 ``replicate:node2``, ``purge:4h:1d:1w``, ``synchronize:node2,node3``. Reading
-that string is all this module does. It touches no disk and runs nothing: what
-a host is worth is decided in ``names.py``, what a retention pattern says in
-``purge.py``, and this module asks them.
+that string is what ``Job.parse`` does, and it does it without touching the
+disk: what a host is worth is decided in ``names.py``, what a retention
+pattern says in ``purge.py``, and this module asks them.
 
 A job keeps the action exactly as the schedule spells it, because that string
 is how the scheduler remembers when the job last ran.
 
 An action nobody could run leaves here as a ``ValidationError``, so no caller
-has to decide what an unknown verb means.
+has to decide what an unknown verb means. A line may well hold such an action:
+an older version wrote it, and it must stay possible to list, to pause and to
+delete. So an ``Entry`` is the line as written, four strings, and reading the
+job out of it is a separate step nobody is forced to take.
+
+``read_schedule`` and ``write_schedule`` are the only place where the CSV
+format is known. They are thin: turning a row into an ``Entry`` is pure, only
+the opening of the file is not. ``read_schedule`` says nothing about a file
+that is not there, because its three callers answer that differently and it is
+their decision, not this module's.
 """
 
+import csv
 from dataclasses import dataclass
 
 from buttervolume import ValidationError
 from buttervolume.names import validate_hostname
 from buttervolume.purge import Pattern
+
+FIELDS = ["Name", "Action", "Timer", "Active"]
 
 
 @dataclass(frozen=True)
@@ -68,3 +80,51 @@ class Synchronize(Job):
     """Snapshot the volume, then pull it back from these hosts."""
 
     hosts: tuple
+
+
+@dataclass(frozen=True)
+class Entry:
+    """One line of the schedule file, as written there.
+
+    Four strings, because that is what the file holds and what the API hands
+    back to its clients. What the action means is ``Job.parse``'s business.
+    """
+
+    name: str
+    action: str
+    timer: str
+    active: str
+
+    @property
+    def enabled(self):
+        """Anything but the word the pause writes means the job runs."""
+        return self.active != "False"
+
+    @classmethod
+    def parse(cls, row):
+        if len(row) != len(FIELDS):
+            raise ValidationError(
+                f"Invalid schedule line {row}. It must have {len(FIELDS)} columns: "
+                f"{', '.join(FIELDS)}"
+            )
+        return cls(*row)
+
+    @property
+    def row(self):
+        return [self.name, self.action, self.timer, self.active]
+
+    @property
+    def fields(self):
+        """The line as the API says it, and as the command line reads it back."""
+        return dict(zip(FIELDS, self.row))
+
+
+def read_schedule(path):
+    """The lines of the schedule file. Raises if the file is not there."""
+    with open(path) as f:
+        return [Entry.parse(row) for row in csv.reader(f)]
+
+
+def write_schedule(path, entries):
+    with open(path, "w", newline="") as f:
+        csv.writer(f).writerows(entry.row for entry in entries)

--- a/buttervolume/schedule.py
+++ b/buttervolume/schedule.py
@@ -18,8 +18,8 @@ job out of it is a separate step nobody is forced to take.
 ``read_schedule`` and ``write_schedule`` are the only place where the CSV
 format is known. They are thin: turning a row into an ``Entry`` is pure, only
 the opening of the file is not. ``read_schedule`` says nothing about a file
-that is not there, because its three callers answer that differently and it is
-their decision, not this module's.
+that is not there, because its callers answer that differently and it is their
+decision, not this module's.
 """
 
 import csv
@@ -102,12 +102,19 @@ class Entry:
 
     @classmethod
     def parse(cls, row):
-        if len(row) != len(FIELDS):
+        """The columns of a line, the missing ones read as empty.
+
+        Buttervolume 3.10 and older wrote three columns, without the ``Active``
+        one, and such a file is still out there: its lines are read as running,
+        which is what they were. A line with more columns than we know is
+        another matter, because writing the file back would lose them.
+        """
+        if len(row) > len(FIELDS):
             raise ValidationError(
-                f"Invalid schedule line {row}. It must have {len(FIELDS)} columns: "
-                f"{', '.join(FIELDS)}"
+                f"Invalid schedule line {row}. It must have at most {len(FIELDS)} "
+                f"columns: {', '.join(FIELDS)}"
             )
-        return cls(*row)
+        return cls(*row, *[""] * (len(FIELDS) - len(row)))
 
     @property
     def row(self):
@@ -119,10 +126,20 @@ class Entry:
         return dict(zip(FIELDS, self.row))
 
 
+def read_rows(path):
+    """The columns of each line, blank lines left out, nothing read of them.
+
+    The scheduler wants them this way: it decides line by line what to do with
+    one it cannot read, and a whole file that refuses to be read would stop
+    every job in it, not just the line at fault.
+    """
+    with open(path) as f:
+        return [row for row in csv.reader(f) if row]
+
+
 def read_schedule(path):
     """The lines of the schedule file. Raises if the file is not there."""
-    with open(path) as f:
-        return [Entry.parse(row) for row in csv.reader(f)]
+    return [Entry.parse(row) for row in read_rows(path)]
 
 
 def write_schedule(path, entries):

--- a/test.py
+++ b/test.py
@@ -2,8 +2,9 @@
 
 Most tests post to the plugin the way Docker does, then check what came back
 and what the snapshots directory holds, so they need a real BTRFS filesystem:
-``./test_local.sh`` sets one up. The ones that need no filesystem at all sit in
-their own classes at the bottom and read names and patterns directly.
+``./test_local.sh`` sets one up. The ones that need no BTRFS sit in their own
+classes at the bottom: they read names, patterns and schedule lines directly,
+on nothing more than a temporary file.
 """
 
 import json
@@ -40,7 +41,7 @@ from buttervolume.plugin import (
     VOLUMES_PATH,
 )
 from buttervolume.purge import Pattern, compute_purges
-from buttervolume.schedule import Job
+from buttervolume.schedule import Entry, Job, read_schedule, write_schedule
 
 # check that the target dir is btrfs
 SCHEDULE = plugin.SCHEDULE = tempfile.mkstemp()[1]
@@ -1346,6 +1347,70 @@ class TestScheduledJob(unittest.TestCase):
         ):
             with self.assertRaises(ValidationError):
                 Job.parse(action)
+
+
+class TestScheduleFile(unittest.TestCase):
+    """The lines of the schedule file, read and written in a single place"""
+
+    def schedule_file(self, content):
+        path = os.path.join(self.tmp, "schedule.csv")
+        with open(path, "w") as f:
+            f.write(content)
+        return path
+
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.tmp = self.tmpdir.name
+        self.addCleanup(self.tmpdir.cleanup)
+
+    def test_a_line_survives_being_read_and_written_back(self):
+        path = self.schedule_file("www,snapshot,60,True\r\nwww,purge:2h,120,False\r\n")
+        entries = read_schedule(path)
+        self.assertEqual(entries[0], Entry("www", "snapshot", "60", "True"))
+        self.assertTrue(entries[0].enabled)
+        self.assertFalse(entries[1].enabled)
+        write_schedule(path, entries)
+        with open(path, newline="") as f:
+            self.assertEqual(f.read(), "www,snapshot,60,True\r\nwww,purge:2h,120,False\r\n")
+
+    def test_the_api_says_a_line_the_way_it_always_did(self):
+        """Clients read these four keys, and read Active as a word, not a boolean"""
+        path = self.schedule_file("www,snapshot,60,False\r\n")
+        self.assertEqual(
+            read_schedule(path)[0].fields,
+            {"Name": "www", "Action": "snapshot", "Timer": "60", "Active": "False"},
+        )
+
+    def test_a_line_nobody_can_read_the_action_of_is_still_a_line(self):
+        """An older version wrote it, and it must stay listable and deletable"""
+        path = self.schedule_file("www,replicat:node2,60,True\r\n")
+        entry = read_schedule(path)[0]
+        self.assertEqual(entry.action, "replicat:node2")
+        with self.assertRaises(ValidationError):
+            Job.parse(entry.action)
+
+    def test_a_line_that_has_not_four_columns_is_refused(self):
+        for content in ("www,snapshot,60\r\n", "www,snapshot,60,True,extra\r\n"):
+            with self.assertRaises(ValidationError):
+                read_schedule(self.schedule_file(content))
+
+    def test_a_schedule_file_that_is_not_there_says_so(self):
+        """Each caller answers that differently, so it is not decided here"""
+        with self.assertRaises(FileNotFoundError):
+            read_schedule(os.path.join(self.tmp, "nothing.csv"))
+
+    def test_converting_the_old_patterns_leaves_every_other_line_alone(self):
+        """Including a line whose action nobody can read: this converts, it does not clean up"""
+        path = self.schedule_file(
+            "www,purge:2h:2h,60,True\r\nwww,replicat:node2,60,True\r\nwww,snapshot,60,False\r\n"
+        )
+        with patch.object(cli, "SCHEDULE", path), patch("builtins.input", lambda: "y"):
+            self.assertTrue(cli._auto_convert_old_patterns())
+        with open(path, newline="") as f:
+            self.assertEqual(
+                f.read(),
+                "www,purge:2h,60,True\r\nwww,replicat:node2,60,True\r\nwww,snapshot,60,False\r\n",
+            )
 
 
 class TemporaryDirectory(tempfile.TemporaryDirectory):

--- a/test.py
+++ b/test.py
@@ -41,7 +41,7 @@ from buttervolume.plugin import (
     VOLUMES_PATH,
 )
 from buttervolume.purge import Pattern, compute_purges
-from buttervolume.schedule import Entry, Job, read_schedule, write_schedule
+from buttervolume.schedule import Entry, Job, read_rows, read_schedule, write_schedule
 
 # check that the target dir is btrfs
 SCHEDULE = plugin.SCHEDULE = tempfile.mkstemp()[1]
@@ -1047,6 +1047,31 @@ class TestCase(unittest.TestCase):
         )
         self.assertEqual(len(os.listdir(SNAPSHOTS_PATH)), nb_snaps)
 
+    def test_the_scheduler_runs_the_lines_around_one_it_cannot_read(self):
+        """A file from Buttervolume 3.10 has three columns, and a hand-edited one anything
+
+        Neither is a reason to stop snapshotting every other volume in the
+        file, which is what reading the whole file in one go would do.
+        """
+        legacy = PREFIX_TEST_VOLUME + uuid.uuid4().hex
+        mangled = PREFIX_TEST_VOLUME + uuid.uuid4().hex
+        healthy = PREFIX_TEST_VOLUME + uuid.uuid4().hex
+        for name in (legacy, mangled, healthy):
+            self.create_a_volume_with_a_file(name)
+        with open(SCHEDULE, "w") as f:
+            f.write(f"{legacy},snapshot,60\n")
+            f.write(f"{mangled},snapshot,60,True,extra\n")
+            f.write(f"{healthy},snapshot,60,True\n")
+
+        with self.assertLogs(level=logging.WARNING) as log_capture:
+            runjobs(config=SCHEDULE, test=True)
+
+        self.assertTrue(any("Invalid schedule line" in msg for msg in log_capture.output))
+        snapshots = os.listdir(SNAPSHOTS_PATH)
+        self.assertTrue(any(s.startswith(legacy) for s in snapshots))
+        self.assertTrue(any(s.startswith(healthy) for s in snapshots))
+        self.assertFalse(any(s.startswith(mangled) for s in snapshots))
+
     def test_a_schedule_nobody_could_run_is_refused(self):
         """The endpoint is where a schedule is written, so it is where it is judged"""
         name = PREFIX_TEST_VOLUME + uuid.uuid4().hex
@@ -1389,10 +1414,29 @@ class TestScheduleFile(unittest.TestCase):
         with self.assertRaises(ValidationError):
             Job.parse(entry.action)
 
-    def test_a_line_that_has_not_four_columns_is_refused(self):
-        for content in ("www,snapshot,60\r\n", "www,snapshot,60,True,extra\r\n"):
-            with self.assertRaises(ValidationError):
-                read_schedule(self.schedule_file(content))
+    def test_a_file_written_before_the_active_column_existed_is_still_read(self):
+        """Buttervolume 3.10 wrote three columns, and nothing ever rewrote those files"""
+        path = self.schedule_file("www,snapshot,60\r\n")
+        self.assertEqual(read_schedule(path), [Entry("www", "snapshot", "60", "")])
+        self.assertTrue(read_schedule(path)[0].enabled)
+
+    def test_a_blank_line_is_not_a_line(self):
+        path = self.schedule_file("www,snapshot,60,True\r\n\r\n")
+        self.assertEqual(len(read_schedule(path)), 1)
+
+    def test_a_line_with_more_columns_than_we_know_is_refused(self):
+        """Writing the file back would lose them, so we do not pretend to read it"""
+        with self.assertRaises(ValidationError):
+            read_schedule(self.schedule_file("www,snapshot,60,True,extra\r\n"))
+
+    def test_a_line_nobody_can_read_stops_only_itself(self):
+        """The scheduler reads line by line: one bad line must not stop the others"""
+        path = self.schedule_file("www,snapshot,60,True,extra\r\nwww,snapshot,60,True\r\n")
+        rows = read_rows(path)
+        self.assertEqual(len(rows), 2)
+        with self.assertRaises(ValidationError):
+            Entry.parse(rows[0])
+        self.assertEqual(Entry.parse(rows[1]), Entry("www", "snapshot", "60", "True"))
 
     def test_a_schedule_file_that_is_not_there_says_so(self):
         """Each caller answers that differently, so it is not decided here"""


### PR DESCRIPTION
`schedule.csv` was opened and cut up in five places: the two endpoints in `plugin.py`, and in `cli.py` the scheduler, the conversion of the old purge patterns and the listing.

Each place did it its own way, and two of those ways were fragile:

- `name, action, timer, enabled = line.values()` relies on the order the columns come back in. A line with one column too many made the unpacking fail; one column short filled the fields with `None` and said nothing.
- Whether a job is active was decided three times with three spellings: `enabled != "False"`, `job.get("Active") == "False"`, and a Python boolean dropped into a dictionary of strings. It worked because `str(False)` happens to be the word written in the file.

`FIELDS` also lived in `plugin.py`, which is not where we decide what a planned job is.

An `Entry` is now that line, four strings, as the file holds it and as the API hands it back. Reading and writing the file belong to `schedule.py`, next to the job its action names. Three decisions worth stating:

- **The `Active` column stays a word.** A boolean would have changed the JSON of `Schedule.List` from `"False"` to `false`, and the listing in `cli.py` compares it to the word: paused jobs would have stopped showing as paused.
- **A line whose action no longer means anything is still a line.** It is read, listed, paused and deleted like the others; only the step that reads the job out of it refuses, which is what #93 asked for.
- **A line written before the `Active` column existed keeps working.** Buttervolume 3.10 and older wrote three columns, and nothing ever rewrote those files. The columns a line does not have are read as empty, which is what they already meant. Only a line with *more* columns than we know is refused, because writing the file back would lose them, and the scheduler reads its lines one at a time so that such a line stops itself rather than the whole schedule.

The command that converts the old purge patterns used to reread the whole file and recognize a purge by the way its action starts. It asks `schedule.py` now, and it leaves every other line exactly as it was, unreadable actions included. The previous version was about to lose them.

Nothing visible changes: the file keeps its bytes, `Schedule.List` keeps its four string fields, and a schedule file from an older version is still read. The new tests check all three.

Next, in their own pull requests: the rewrite of `schedule.csv` is not atomic, so an interruption at the wrong moment empties the only state the plugin keeps outside BTRFS; and `runjobs` still decides what is due and runs it in the same function.
