### PR TITLE
Replace the schedule file in one go instead of emptying it first

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,14 @@ CHANGELOG
 3.13 (unreleased)
 *****************
 
+- Saving a scheduled job no longer risks losing the whole schedule.
+  ``schedule.csv`` was emptied before being written back, and it is rewritten
+  in full every time a job is added, paused, resumed or removed, so an
+  interruption in that window left an empty or half-written file. Nobody would
+  notice: the next scheduler run reported no config file, or read half of the
+  jobs, and the scheduled snapshots stopped in silence. The file is now written
+  beside itself and renamed over the old one, which happens in one go.
+
 - The scheduler now reports a line of ``schedule.csv`` whose action it does
   not know, instead of skipping it silently at every run. The guard meant to
   do this could never fire, so a misspelled ``replicat:host`` looked exactly

--- a/buttervolume/schedule.py
+++ b/buttervolume/schedule.py
@@ -159,9 +159,16 @@ def write_schedule(path, entries):
     A rename replaces a name, where the previous write followed it: the file
     written is the one the path really designates, so a schedule reached
     through a symbolic link keeps being the file it points at.
+
+    A machine that stops between the temporary file and the rename leaves that
+    temporary file behind. Nothing here removes it: it is named after the
+    schedule so that whoever finds it knows what it is, and deleting files
+    nobody asked to delete is how a schedule gets lost.
     """
     path = os.path.realpath(path)
-    fd, tmp = tempfile.mkstemp(dir=os.path.dirname(path) or ".")
+    # the name says whose leftover it is, on the day a machine stops between
+    # this line and the rename below and leaves one behind
+    fd, tmp = tempfile.mkstemp(dir=os.path.dirname(path) or ".", prefix="schedule.")
     try:
         with os.fdopen(fd, "w", newline="") as f:
             csv.writer(f).writerows(entry.row for entry in entries)
@@ -169,11 +176,14 @@ def write_schedule(path, entries):
             # without this, a crash can bring the rename to the disk before
             # the lines it renames, which is the empty file we are avoiding
             os.fsync(f.fileno())
-        # the file being replaced keeps the mode it had; a temporary file is
-        # readable by nobody else, and a schedule that names volumes and hosts
-        # has no reason to be born more open than that
+        # renaming gives a new file where writing in place kept the old one,
+        # so the mode and the hands of the one being replaced are put back. A
+        # temporary file is readable by nobody else, and a schedule that names
+        # volumes and hosts has no reason to be born more open than that
         with suppress(FileNotFoundError):
-            os.chmod(tmp, stat.S_IMODE(os.stat(path).st_mode))
+            previous = os.stat(path)
+            os.chmod(tmp, stat.S_IMODE(previous.st_mode))
+            os.chown(tmp, previous.st_uid, previous.st_gid)
         os.replace(tmp, path)
     except BaseException:
         os.unlink(tmp)

--- a/buttervolume/schedule.py
+++ b/buttervolume/schedule.py
@@ -28,6 +28,7 @@ import csv
 import os
 import stat
 import tempfile
+from contextlib import suppress
 from dataclasses import dataclass
 
 from buttervolume import ValidationError
@@ -154,10 +155,12 @@ def write_schedule(path, entries):
     and an interruption there loses the whole schedule. So the lines are
     written next to it and the file is renamed over the old one, which is
     atomic within a filesystem, hence the temporary file in the same directory.
+
+    A rename replaces a name, where the previous write followed it: the file
+    written is the one the path really designates, so a schedule reached
+    through a symbolic link keeps being the file it points at.
     """
-    # the file that is being replaced says what mode it wants; a schedule
-    # written for the first time is readable, as opening it in place made it
-    mode = stat.S_IMODE(os.stat(path).st_mode) if os.path.exists(path) else 0o644
+    path = os.path.realpath(path)
     fd, tmp = tempfile.mkstemp(dir=os.path.dirname(path) or ".")
     try:
         with os.fdopen(fd, "w", newline="") as f:
@@ -166,7 +169,11 @@ def write_schedule(path, entries):
             # without this, a crash can bring the rename to the disk before
             # the lines it renames, which is the empty file we are avoiding
             os.fsync(f.fileno())
-        os.chmod(tmp, mode)
+        # the file being replaced keeps the mode it had; a temporary file is
+        # readable by nobody else, and a schedule that names volumes and hosts
+        # has no reason to be born more open than that
+        with suppress(FileNotFoundError):
+            os.chmod(tmp, stat.S_IMODE(os.stat(path).st_mode))
         os.replace(tmp, path)
     except BaseException:
         os.unlink(tmp)

--- a/buttervolume/schedule.py
+++ b/buttervolume/schedule.py
@@ -19,10 +19,15 @@ job out of it is a separate step nobody is forced to take.
 format is known. They are thin: turning a row into an ``Entry`` is pure, only
 the opening of the file is not. ``read_schedule`` says nothing about a file
 that is not there, because its callers answer that differently and it is their
-decision, not this module's.
+decision, not this module's. ``write_schedule`` replaces the file in one go,
+because it is the only state the plugin keeps outside BTRFS and a half-written
+schedule is a lost one.
 """
 
 import csv
+import os
+import stat
+import tempfile
 from dataclasses import dataclass
 
 from buttervolume import ValidationError
@@ -143,5 +148,26 @@ def read_schedule(path):
 
 
 def write_schedule(path, entries):
-    with open(path, "w", newline="") as f:
-        csv.writer(f).writerows(entry.row for entry in entries)
+    """Replace the file in one go, or leave it exactly as it was.
+
+    Writing in place would empty the file before knowing what goes back in it,
+    and an interruption there loses the whole schedule. So the lines are
+    written next to it and the file is renamed over the old one, which is
+    atomic within a filesystem, hence the temporary file in the same directory.
+    """
+    # the file that is being replaced says what mode it wants; a schedule
+    # written for the first time is readable, as opening it in place made it
+    mode = stat.S_IMODE(os.stat(path).st_mode) if os.path.exists(path) else 0o644
+    fd, tmp = tempfile.mkstemp(dir=os.path.dirname(path) or ".")
+    try:
+        with os.fdopen(fd, "w", newline="") as f:
+            csv.writer(f).writerows(entry.row for entry in entries)
+            f.flush()
+            # without this, a crash can bring the rename to the disk before
+            # the lines it renames, which is the empty file we are avoiding
+            os.fsync(f.fileno())
+        os.chmod(tmp, mode)
+        os.replace(tmp, path)
+    except BaseException:
+        os.unlink(tmp)
+        raise

--- a/test.py
+++ b/test.py
@@ -1421,6 +1421,19 @@ class TestScheduleFile(unittest.TestCase):
         write_schedule(path, read_schedule(path))
         self.assertEqual(stat.S_IMODE(os.stat(path).st_mode), 0o640)
 
+    def test_writing_the_schedule_keeps_the_hands_of_the_file_it_replaces(self):
+        """Renaming gives a new file, where writing in place kept the old one"""
+        path = self.schedule_file("www,snapshot,60,True\r\n")
+        mine = os.stat(path).st_gid
+        # root belongs to its own group alone and may give a file to any other
+        other = next((g for g in os.getgroups() if g != mine), mine + 1)
+        try:
+            os.chown(path, -1, other)
+        except PermissionError:
+            self.skipTest("no other group to give the schedule to")
+        write_schedule(path, read_schedule(path))
+        self.assertEqual(os.stat(path).st_gid, other)
+
     def test_a_schedule_reached_through_a_symbolic_link_stays_that_file(self):
         """A rename replaces a name, so the link is followed before renaming"""
         target = os.path.join(self.tmp, "elsewhere.csv")

--- a/test.py
+++ b/test.py
@@ -11,6 +11,7 @@ import json
 import logging
 import os
 import shutil
+import stat
 import subprocess
 import tempfile
 import threading
@@ -1397,6 +1398,28 @@ class TestScheduleFile(unittest.TestCase):
         write_schedule(path, entries)
         with open(path, newline="") as f:
             self.assertEqual(f.read(), "www,snapshot,60,True\r\nwww,purge:2h,120,False\r\n")
+
+    def test_an_interrupted_write_leaves_the_previous_schedule_alone(self):
+        """This file is the only state outside BTRFS, and half of it is none of it"""
+        content = "www,snapshot,60,True\r\nwww,purge:2h,120,False\r\n"
+        path = self.schedule_file(content)
+
+        def entries():
+            yield Entry("www", "snapshot", "60", "True")
+            raise OSError("No space left on device")
+
+        with self.assertRaises(OSError):
+            write_schedule(path, entries())
+        with open(path, newline="") as f:
+            self.assertEqual(f.read(), content)
+        self.assertEqual(os.listdir(self.tmp), ["schedule.csv"])
+
+    def test_writing_the_schedule_keeps_the_mode_of_the_file_it_replaces(self):
+        """Saving a job is no reason for the file to change hands"""
+        path = self.schedule_file("www,snapshot,60,True\r\n")
+        os.chmod(path, 0o640)
+        write_schedule(path, read_schedule(path))
+        self.assertEqual(stat.S_IMODE(os.stat(path).st_mode), 0o640)
 
     def test_the_api_says_a_line_the_way_it_always_did(self):
         """Clients read these four keys, and read Active as a word, not a boolean"""

--- a/test.py
+++ b/test.py
@@ -1421,6 +1421,24 @@ class TestScheduleFile(unittest.TestCase):
         write_schedule(path, read_schedule(path))
         self.assertEqual(stat.S_IMODE(os.stat(path).st_mode), 0o640)
 
+    def test_a_schedule_reached_through_a_symbolic_link_stays_that_file(self):
+        """A rename replaces a name, so the link is followed before renaming"""
+        target = os.path.join(self.tmp, "elsewhere.csv")
+        with open(target, "w") as f:
+            f.write("www,snapshot,60,True\r\n")
+        link = os.path.join(self.tmp, "schedule.csv")
+        os.symlink(target, link)
+        write_schedule(link, [Entry("www", "snapshot", "120", "True")])
+        self.assertTrue(os.path.islink(link))
+        with open(target, newline="") as f:
+            self.assertEqual(f.read(), "www,snapshot,120,True\r\n")
+
+    def test_a_schedule_written_where_there_was_none_is_read_by_nobody_else(self):
+        """It names volumes and hosts, so it is born no more open than that"""
+        path = os.path.join(self.tmp, "new.csv")
+        write_schedule(path, [Entry("www", "snapshot", "60", "True")])
+        self.assertEqual(stat.S_IMODE(os.stat(path).st_mode), 0o600)
+
     def test_the_api_says_a_line_the_way_it_always_did(self):
         """Clients read these four keys, and read Active as a word, not a boolean"""
         path = self.schedule_file("www,snapshot,60,False\r\n")


### PR DESCRIPTION
The schedule file was opened in write mode, which truncates it, and only then were its lines written back. Between the two it held nothing, and it is rewritten in full every time a job is added, paused, resumed or removed. An interruption in that window left an empty or half-written file, and nobody would notice: the next scheduler run reported no config file, or read half of the jobs, and the scheduled snapshots stopped in silence. This is the only state the plugin keeps outside BTRFS, so losing it loses everything the user asked for.

The lines are now written to a temporary file in the same directory, flushed to the disk, and renamed over the old one. Renaming within a filesystem happens in one go, so a reader sees either the previous schedule or the new one. The pull request #96 had made every writer go through `write_schedule`, so this is one repair in one place: both the `Schedule` endpoint and `scheduled --auto-convert-old-patterns` are covered by it.

Two details worth a look:

- The flush to the disk is deliberate. Without it, a machine that stops brutally could bring the rename to the disk before the lines it renames, which is exactly the empty file this is about. The directory itself is not synced: losing the rename gives back the old file, which is the state we were protecting anyway.
- A temporary file is created readable only by its owner, so the mode of the file being replaced is put back before the rename. Otherwise saving a job would silently turn `schedule.csv` from 0644 into 0600.

What this does not do: it says nothing about two writers at once. The rename means neither of them leaves a cut file, not that the second does not overwrite the first. Waitress answers on several threads, so the case exists, and it needs a decision about where a lock would live.

Tests: an interrupted write leaves the previous file intact and no temporary file behind. It fails on master, where the file comes out truncated to its first line. 55 tests pass, 4 skipped for lack of SSH locally, ruff clean.