### PR TITLE
Let the scheduler decide first and act afterwards

### DIFF
--- a/buttervolume/cli.py
+++ b/buttervolume/cli.py
@@ -466,7 +466,7 @@ def run_synchronize(job: Synchronize, name, test=False):
     return True
 
 
-def runjobs(config=SCHEDULE, test=False, schedule_log=None, timer=TIMER):
+def runjobs(config=SCHEDULE, test=False, schedule_log=None):
     if schedule_log is None:
         schedule_log = {"snapshot": {}, "replicate": {}, "synchronize": {}}
     if exists(SCHEDULE_DISABLED):
@@ -537,7 +537,7 @@ def scheduler(event, config=SCHEDULE, test=False, timer=TIMER):
             return
         else:
             try:
-                runjobs(config, test, schedule_log=schedule_log, timer=timer)
+                runjobs(config, test, schedule_log=schedule_log)
             except Exception:
                 log.critical("An exception occured in the scheduling job")
                 log.critical(traceback.format_exc())

--- a/buttervolume/cli.py
+++ b/buttervolume/cli.py
@@ -12,8 +12,9 @@ a synchronization or a purge. Reading that file, and reading what each of its
 lines asks for, is ``schedule.py``'s business. What is left here is done in two
 steps that do not mix: ``is_due`` decides, from a line, a date and a clock,
 without touching anything; ``run_job`` does the work, one function per kind of
-job. ``schedule.csv`` is the only state the plugin keeps outside BTRFS, and
-when a job last ran is the only state it keeps in memory alone.
+job. ``schedule.csv`` is the only state the plugin keeps outside BTRFS; when
+a job last ran, and which replications are under way, live in memory alone and
+are forgotten when the daemon stops.
 """
 
 import argparse

--- a/buttervolume/cli.py
+++ b/buttervolume/cli.py
@@ -9,8 +9,11 @@ daemon exists, and ``scheduled --auto-convert-old-patterns`` rewrites
 
 The scheduler runs what is due in ``schedule.csv``: a snapshot, a replication,
 a synchronization or a purge. Reading that file, and reading what each of its
-lines asks for, is ``schedule.py``'s business, so the loop below only has to
-run it. That file is the only state the plugin keeps outside BTRFS.
+lines asks for, is ``schedule.py``'s business. What is left here is done in two
+steps that do not mix: ``is_due`` decides, from a line, a date and a clock,
+without touching anything; ``run_job`` does the work, one function per kind of
+job. ``schedule.csv`` is the only state the plugin keeps outside BTRFS, and
+when a job last ran is the only state it keeps in memory alone.
 """
 
 import argparse
@@ -27,6 +30,7 @@ import urllib.parse
 from contextlib import suppress
 from dataclasses import replace
 from datetime import datetime, timedelta
+from functools import singledispatch
 from os.path import exists
 from subprocess import CalledProcessError
 
@@ -54,6 +58,7 @@ from buttervolume.schedule import (
     Purge,
     Replicate,
     Snapshot,
+    Synchronize,
     read_rows,
     read_schedule,
     write_schedule,
@@ -343,6 +348,124 @@ class Arg:
             setattr(self, k, v)
 
 
+def is_due(entry, last, now):
+    """Has this line waited its timer since the last time it ran?
+
+    Pure: a line, a date and a clock, nothing else. The clock is given rather
+    than read here, so deciding what is due can be tested without a volume, a
+    daemon or a filesystem.
+    """
+    return now >= last + timedelta(minutes=int(entry.timer))
+
+
+@singledispatch
+def run_job(job, name, test=False):
+    """Run one scheduled job on one volume, and say whether its turn is spent.
+
+    True means the job must not be tried again before its timer has elapsed
+    once more; False means the next scheduler round tries it again. The four
+    jobs below do not answer the same thing after a failure, and never have: a
+    snapshot or a replication that failed comes back at the next round, a purge
+    that failed waits for its next turn. Nobody decided that, and it is now
+    said in four visible places instead of being buried in one long branch.
+
+    Getting here means Job.parse accepted an action that nothing knows how to
+    run. The caller logs it and moves on to the next line, which is what an
+    action we cannot run deserves.
+    """
+    raise ValidationError(f"Nothing runs a {type(job).__name__} job")
+
+
+@run_job.register
+def run_snapshot(job: Snapshot, name, test=False):
+    log.info("Starting scheduled snapshot of %s", name)
+    snap = snapshot(Arg(name=[name]), test=test)
+    if not snap:
+        log.info("Could not snapshot %s", name)
+        return False
+    log.info("Successfully snapshotted to %s", snap)
+    return True
+
+
+@run_job.register
+def run_replicate(job: Replicate, name, test=False):
+    if name in ReplicationInProgress:
+        log.warning(f"Replication of {name} already in progress, skipping.")
+        return False
+    log.info("Starting scheduled replication of %s", name)
+    snap = None
+    try:
+        ReplicationInProgress.add(name)
+        snap = snapshot(Arg(name=[name]), test=test)
+        if not snap:
+            log.info("Could not snapshot %s", name)
+            return False
+        log.info("Successfully snapshotted to %s", snap)
+        if not send(Arg(snapshot=[snap], host=[job.host]), test=test):
+            # the same road as an exception: the error is already logged,
+            # and the snapshot taken for this replication has no reason to stay
+            raise ReplicationError(f"Could not send {snap} to {job.host}")
+        log.info("Successfully replicated %s to %s", name, snap)
+        return True
+    except Exception as e:
+        log.warning("Replication failed: %s", e)
+        # remove snapshot that was created for the failed replication
+        if snap:
+            if remove(Arg(name=[snap]), test=test):
+                log.info("Removed snapshot %s for failed replication", snap)
+            else:
+                log.warning(
+                    "Could not remove snapshot %s of the failed replication",
+                    snap,
+                )
+        return False
+    finally:
+        ReplicationInProgress.remove(name)
+
+
+@run_job.register
+def run_purge(job: Purge, name, test=False):
+    pattern = job.pattern
+    log.info(
+        "Starting scheduled purge of %s with pattern %s",
+        name,
+        pattern.deprecated or pattern.text,
+    )
+    # A deprecated pattern is converted and reported, not refused
+    if pattern.deprecated:
+        log.warning(
+            "Converting deprecated pattern '%s' to '%s'. Please update your "
+            "schedule using 'buttervolume scheduled --auto-convert-old-patterns'.",
+            pattern.deprecated,
+            pattern.text,
+        )
+    if purge(Arg(name=[name], pattern=[pattern.text], dryrun=False), test=test):
+        log.info("Finished purging")
+    else:
+        log.warning("Could not purge the snapshots of %s", name)
+    # a purge that failed waits for its next turn all the same, as it always has
+    return True
+
+
+@run_job.register
+def run_synchronize(job: Synchronize, name, test=False):
+    log.info("Starting scheduled synchronization of %s", name)
+    hosts = list(job.hosts)
+    # do a snapshot to save state before pulling data
+    snap = snapshot(Arg(name=[name]), test=test)
+    if not snap:
+        log.info("Could not snapshot %s", name)
+        return False
+    log.debug("Successfully snapshotted to %s", snap)
+    if sync(Arg(volumes=[name], hosts=hosts), test=test):
+        log.debug("End of %s synchronization from %s", name, hosts)
+    else:
+        log.warning("Could not synchronize %s from %s", name, hosts)
+    # like the purge, a synchronization that could not pull the data back
+    # still considers its turn spent
+    return True
+
+
 def runjobs(config=SCHEDULE, test=False, schedule_log=None, timer=TIMER):
     if schedule_log is None:
         schedule_log = {"snapshot": {}, "replicate": {}, "synchronize": {}}
@@ -376,85 +499,9 @@ def runjobs(config=SCHEDULE, test=False, schedule_log=None, timer=TIMER):
             # just starting, we consider beeing late on snapshots
             schedule_log.setdefault(action, {})
             schedule_log[action].setdefault(name, now - timedelta(1))
-            last = schedule_log[action][name]
-            if now < last + timedelta(minutes=int(timer)):
+            if not is_due(entry, schedule_log[action][name], now):
                 continue
-            # choose and run the right action
-            if isinstance(job, Snapshot):
-                log.info("Starting scheduled snapshot of %s", name)
-                snap = snapshot(Arg(name=[name]), test=test)
-                if not snap:
-                    log.info("Could not snapshot %s", name)
-                    continue
-                log.info("Successfully snapshotted to %s", snap)
-                schedule_log[action][name] = now
-            elif isinstance(job, Replicate):
-                if name in ReplicationInProgress:
-                    log.warning(f"Replication of {name} already in progress, skipping.")
-                    continue
-                log.info("Starting scheduled replication of %s", name)
-                snap = None
-                try:
-                    ReplicationInProgress.add(name)
-                    snap = snapshot(Arg(name=[name]), test=test)
-                    if not snap:
-                        log.info("Could not snapshot %s", name)
-                        continue
-                    log.info("Successfully snapshotted to %s", snap)
-                    if not send(Arg(snapshot=[snap], host=[job.host]), test=test):
-                        # the same road as an exception: the error is
-                        # already logged, and the snapshot taken for this
-                        # replication has no reason to stay
-                        raise ReplicationError(f"Could not send {snap} to {job.host}")
-                    log.info("Successfully replicated %s to %s", name, snap)
-                    schedule_log[action][name] = now
-                except Exception as e:
-                    log.warning("Replication failed: %s", e)
-                    # remove snapshot that was created for the failed replication
-                    if snap:
-                        if remove(Arg(name=[snap]), test=test):
-                            log.info("Removed snapshot %s for failed replication", snap)
-                        else:
-                            log.warning(
-                                "Could not remove snapshot %s of the failed replication",
-                                snap,
-                            )
-                finally:
-                    ReplicationInProgress.remove(name)
-            elif isinstance(job, Purge):
-                parsed = job.pattern
-                log.info(
-                    "Starting scheduled purge of %s with pattern %s",
-                    name,
-                    parsed.deprecated or parsed.text,
-                )
-                # A deprecated pattern is converted and reported, not refused
-                if parsed.deprecated:
-                    log.warning(
-                        "Converting deprecated pattern '%s' to '%s'. Please update your "
-                        "schedule using 'buttervolume scheduled --auto-convert-old-patterns'.",
-                        parsed.deprecated,
-                        parsed.text,
-                    )
-
-                if purge(Arg(name=[name], pattern=[parsed.text], dryrun=False), test=test):
-                    log.info("Finished purging")
-                else:
-                    log.warning("Could not purge the snapshots of %s", name)
-                schedule_log[action][name] = now
-            else:  # a Synchronize, the only job left
-                log.info("Starting scheduled synchronization of %s", name)
-                hosts = list(job.hosts)
-                # do a snapshot to save state before pulling data
-                snap = snapshot(Arg(name=[name]), test=test)
-                if not snap:
-                    log.info("Could not snapshot %s", name)
-                    continue
-                log.debug("Successfully snapshotted to %s", snap)
-                if sync(Arg(volumes=[name], hosts=hosts), test=test):
-                    log.debug("End of %s synchronization from %s", name, hosts)
-                else:
-                    log.warning("Could not synchronize %s from %s", name, hosts)
+            if run_job(job, name, test=test):
                 schedule_log[action][name] = now
         except CalledProcessError as e:
             log.error(

--- a/buttervolume/cli.py
+++ b/buttervolume/cli.py
@@ -44,7 +44,6 @@ from buttervolume import ReplicationError, ValidationError
 from buttervolume.plugin import (
     LOGLEVEL,
     SCHEDULE,
-    SCHEDULE_DISABLED,
     SNAPSHOTS_PATH,
     SOCKET,
     TIMER,
@@ -469,8 +468,6 @@ def run_synchronize(job: Synchronize, name, test=False):
 def runjobs(config=SCHEDULE, test=False, schedule_log=None):
     if schedule_log is None:
         schedule_log = {"snapshot": {}, "replicate": {}, "synchronize": {}}
-    if exists(SCHEDULE_DISABLED):
-        log.info("Schedule is globally paused")
     log.info("New scheduler job at %s", datetime.now())
     # open the config and launch the tasks
     if not exists(config):

--- a/test.py
+++ b/test.py
@@ -28,7 +28,7 @@ from unittest.mock import MagicMock, patch
 from webtest import TestApp
 
 from buttervolume import ValidationError, btrfs, cli, plugin, schedule
-from buttervolume.cli import init_btrfs, runjobs
+from buttervolume.cli import init_btrfs, is_due, run_job, runjobs
 from buttervolume.names import (
     Snapshot,
     new_snapshot,
@@ -1373,6 +1373,48 @@ class TestScheduledJob(unittest.TestCase):
         ):
             with self.assertRaises(ValidationError):
                 Job.parse(action)
+
+
+class TestWhatIsDue(unittest.TestCase):
+    """When a line's turn has come, decided on paper
+
+    No volume, no daemon and no schedule file: the decision has never needed
+    more than a line, the date of its last run and a clock.
+    """
+
+    def hourly(self):
+        return Entry("volume", "snapshot", "60", "True")
+
+    def test_a_line_waits_for_its_timer(self):
+        now = datetime(2026, 8, 26, 12, 0)
+        self.assertFalse(is_due(self.hourly(), now - timedelta(minutes=59), now))
+
+    def test_a_line_whose_timer_has_elapsed_is_due(self):
+        now = datetime(2026, 8, 26, 12, 0)
+        self.assertTrue(is_due(self.hourly(), now - timedelta(minutes=60), now))
+
+    def test_a_line_the_scheduler_has_never_seen_is_due(self):
+        """A daemon that just started writes down a day of lateness for it"""
+        now = datetime(2026, 8, 26, 12, 0)
+        self.assertTrue(is_due(self.hourly(), now - timedelta(days=1), now))
+
+
+class TestRunningAJob(unittest.TestCase):
+    """Which function runs which kind of job"""
+
+    def test_a_job_nobody_knows_how_to_run_says_so(self):
+        """Job.parse builds the four kinds the command line knows how to run
+
+        A fifth one added there without its execution here used to fall into
+        the last branch and be synchronized. It now names itself and stops,
+        and the scheduler reports it like any other line that failed.
+        """
+
+        class Rewind(Job):
+            pass
+
+        with self.assertRaises(ValidationError):
+            run_job(Rewind("rewind"), "volume", test=True)
 
 
 class TestScheduleFile(unittest.TestCase):


### PR DESCRIPTION
`runjobs` read the schedule file, skipped the paused lines, refused the unknown
actions, worked out whether the timer had elapsed, and then ran the snapshot,
the replication, the purge or the synchronization, each with its own error
handling, in one function of a hundred and forty lines.

Two things followed from that.

Knowing whether a line is due asks for a line, a date and a clock. It took a
BTRFS filesystem, a daemon and a volume to test it. That decision is now
`is_due`, which touches nothing and is tested on paper.

The four actions were four branches of one `isinstance` chain, written at four
different moments, and they do not agree on what to do after a failure: a
snapshot or a replication that failed comes back at the next scheduler round, a
purge that failed waits for its next turn. Each action is now a function of its
own, chosen by the type of the job, and each one says what it does with a
failure by returning whether its turn is spent. The disagreement is untouched
and visible in four places instead of being buried in one long branch, which is
what it takes before deciding whether to keep it.

Nothing changes for whoever runs the plugin. The same lines run at the same
moments, the same messages are written, the same dates are kept. Hence no
changelog entry.

Two smaller things went with it, in their own commits, because they live in the
function being rewritten and disappear on their own once it is:

- `runjobs` took a `timer` argument that the first line of its body overwrote
  before anything could read it.
- It opened with a look at the global pause file and wrote "Schedule is
  globally paused", then carried on as if nothing had happened; four lines
  below, the same state is seen again on the file the caller was actually
  given, and that check both reports it and returns. Whoever watched their logs
  for that sentence now reads "Config file disabled", written at the same
  moment by the check that really stops the jobs.

Two behaviours this deliberately leaves alone, each worth its own pull request:
a purge that failed still waits a full period before being tried again, and a
line the scheduler has never seen still starts a day late, so a weekly job
waits six days after a restart.

62 tests pass, 4 skipped for want of SSH locally, `ruff` clean.
