### PR TITLE
Count a purge's period from its last success, not its last attempt

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,16 @@ CHANGELOG
 3.13 (unreleased)
 *****************
 
+- A scheduled purge that failed is now tried again at the next scheduler
+  round. Its date was written down whether it had worked or not, so a failure
+  meant waiting a whole period, usually a day, before anything tried again,
+  while a failed snapshot or replication came back a minute later. A purge
+  leaves nothing behind when it fails, so there is nothing to gain from
+  waiting. A synchronization is the one job that still spends its turn on a
+  failure, because it takes a snapshot of the volume before rsync overwrites
+  it, and retrying every minute would leave one snapshot per minute behind
+  while the other host is away.
+
 - Saving a scheduled job no longer risks losing the whole schedule.
   ``schedule.csv`` was emptied before being written back, and it is rewritten
   in full every time a job is added, paused, resumed or removed, so an

--- a/buttervolume/cli.py
+++ b/buttervolume/cli.py
@@ -362,12 +362,13 @@ def is_due(entry, last, now):
 def run_job(job, name, test=False):
     """Run one scheduled job on one volume, and say whether its turn is spent.
 
-    True means the job must not be tried again before its timer has elapsed
-    once more; False means the next scheduler round tries it again. The four
-    jobs below do not answer the same thing after a failure, and never have: a
-    snapshot or a replication that failed comes back at the next round, a purge
-    that failed waits for its next turn. Nobody decided that, and it is now
-    said in four visible places instead of being buried in one long branch.
+    The scheduler writes down the date of a job that answers True and counts
+    its timer from there, so a job that answers False comes back at the next
+    round instead of waiting a full period. Three of the four say plainly
+    whether they succeeded. The synchronization does not: it takes a snapshot
+    of the volume before rsync overwrites it, and that snapshot cannot be
+    taken back, so a failed pull spends its turn rather than leave one behind
+    every minute for as long as the other host is away.
 
     Getting here means Job.parse accepted an action that nothing knows how to
     run. The caller logs it and moves on to the next line, which is what an
@@ -439,11 +440,10 @@ def run_purge(job: Purge, name, test=False):
             pattern.deprecated,
             pattern.text,
         )
-    if purge(Arg(name=[name], pattern=[pattern.text], dryrun=False), test=test):
-        log.info("Finished purging")
-    else:
+    if not purge(Arg(name=[name], pattern=[pattern.text], dryrun=False), test=test):
         log.warning("Could not purge the snapshots of %s", name)
-    # a purge that failed waits for its next turn all the same, as it always has
+        return False
+    log.info("Finished purging")
     return True
 
 
@@ -461,8 +461,10 @@ def run_synchronize(job: Synchronize, name, test=False):
         log.debug("End of %s synchronization from %s", name, hosts)
     else:
         log.warning("Could not synchronize %s from %s", name, hosts)
-    # like the purge, a synchronization that could not pull the data back
-    # still considers its turn spent
+    # the turn is spent either way: the snapshot taken above holds the volume
+    # as it was before rsync, it is what a pull stopped halfway is recovered
+    # from, and coming back at the next round would take a new one every
+    # minute while the other host is away
     return True
 
 
@@ -499,6 +501,8 @@ def runjobs(config=SCHEDULE, test=False, schedule_log=None):
             schedule_log[action].setdefault(name, now - timedelta(1))
             if not is_due(entry, schedule_log[action][name], now):
                 continue
+            # the date a job answered for, so one that failed and can be
+            # tried again comes back at the next round
             if run_job(job, name, test=test):
                 schedule_log[action][name] = now
         except CalledProcessError as e:

--- a/test.py
+++ b/test.py
@@ -1024,6 +1024,47 @@ class TestCase(unittest.TestCase):
             json.dumps({"Name": name, "Action": "purge:2h:2h", "Timer": 0}),
         )
 
+    def test_a_purge_that_failed_is_tried_again_at_the_next_round(self):
+        """A job whose date is written down anyway is a job nobody retries
+
+        The scheduler counted the period of a purge from the moment it ran it,
+        whether it worked or not, so a purge that failed went quiet until its
+        next turn, which is a day for most schedules.
+        """
+        name = PREFIX_TEST_VOLUME + uuid.uuid4().hex
+        self.create_a_volume_with_a_file(name)
+        with open(SCHEDULE, "w") as f:
+            f.write(f"{name},purge:2h,60,True\n")
+        schedule_log = {}
+
+        with patch("buttervolume.cli.purge", return_value=False) as failing_purge:
+            runjobs(config=SCHEDULE, test=True, schedule_log=schedule_log)
+            runjobs(config=SCHEDULE, test=True, schedule_log=schedule_log)
+
+        self.assertEqual(failing_purge.call_count, 2)
+
+    def test_a_synchronization_that_could_not_pull_waits_for_its_turn(self):
+        """A purge that failed can be tried again for free, a pull cannot
+
+        The snapshot taken before the pull holds the volume as it was before
+        rsync, and it is what a pull stopped halfway is recovered from, so it
+        stays. Coming back at the next round would therefore leave one
+        snapshot per minute behind while the other host is away.
+        """
+        name = PREFIX_TEST_VOLUME + uuid.uuid4().hex
+        self.create_a_volume_with_a_file(name)
+        with open(SCHEDULE, "w") as f:
+            f.write(f"{name},synchronize:localhost,60,True\n")
+        schedule_log = {}
+
+        with patch("buttervolume.cli.sync", return_value=False) as failing_sync:
+            runjobs(config=SCHEDULE, test=True, schedule_log=schedule_log)
+            runjobs(config=SCHEDULE, test=True, schedule_log=schedule_log)
+
+        self.assertEqual(failing_sync.call_count, 1)
+        snapshots = [s for s in os.listdir(SNAPSHOTS_PATH) if s.startswith(name + "@")]
+        self.assertEqual(len(snapshots), 1)
+
     def test_an_unknown_scheduled_action_is_reported(self):
         """A misspelled action in the schedule must be said out loud
 


### PR DESCRIPTION
Stacked on #98, which it needs. Review that one first.

The scheduler wrote down the date of a purge whether it had worked or not, so a
purge that failed went quiet until its next turn, usually a day later, while a
snapshot or a replication that failed came back at the next round, a minute
later. Nobody chose either rule: they are what four branches written at four
different moments happened to do, and #98 is what made the disagreement visible.

Waiting a day is the wrong half of that, because a purge that failed leaves
nothing behind and costs nothing to try again. It fails because the volume is
gone, the disk is full or a snapshot is busy, and none of those is a reason to
stop saying so. A purge that keeps failing now says so at every round, which is
loud, but an error that repeats is an error that is still there.

The synchronization keeps spending its turn on a failed pull, and that is now
written down rather than inherited. It takes a snapshot of the volume before
rsync overwrites it, and that snapshot is what a pull stopped halfway is
recovered from, so it stays. Coming back every minute while the other host is
away would leave one snapshot per minute behind, and a volume with no purge
scheduled would keep every single one. Its preliminary snapshot already came
back at the next round when it failed, and does not change.

Two tests, one per job: the failing purge is tried twice in two rounds, the
failing pull once and with a single snapshot to show for it. The first fails on
#98.

64 tests pass, 4 skipped for want of SSH locally, `ruff` clean.
