### PR TITLE
Run at once a job the daemon has never run

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,16 @@ CHANGELOG
 
 - A scheduled purge that failed is now tried again at the next scheduler
   round. Its date was written down whether it had worked or not, so a failure
+- A scheduled job the running daemon has never run now runs at once, instead
+  of starting a day late. The scheduler keeps in memory when each job last ran
+  and forgets it when it stops, and for a job it had never seen it pretended
+  the last run was exactly one day old. A job of a shorter period therefore
+  started immediately, while a weekly one waited six days after every restart
+  and a monthly one twenty-nine, without a word.
+
+- A scheduled purge that failed, and a scheduled synchronization that could
+  not pull the data back, are now tried again at the next scheduler round.
+  Their date was written down whether they had worked or not, so a failure
   meant waiting a whole period, usually a day, before anything tried again,
   while a failed snapshot or replication came back a minute later. A purge
   leaves nothing behind when it fails, so there is nothing to gain from

--- a/buttervolume/cli.py
+++ b/buttervolume/cli.py
@@ -496,10 +496,10 @@ def runjobs(config=SCHEDULE, test=False, schedule_log=None):
                 log.warning("Skipping the unknown action %s of %s: %s", action, name, e)
                 continue
             now = datetime.now()
-            # just starting, we consider beeing late on snapshots
-            schedule_log.setdefault(action, {})
-            schedule_log[action].setdefault(name, now - timedelta(1))
-            if not is_due(entry, schedule_log[action][name], now):
+            # a line this scheduler never ran is due: it is the first thing
+            # a freshly started daemon owes the volumes it was given
+            last = schedule_log.setdefault(action, {}).get(name)
+            if last is not None and not is_due(entry, last, now):
                 continue
             # the date a job answered for, so one that failed and can be
             # tried again comes back at the next round

--- a/test.py
+++ b/test.py
@@ -1065,6 +1065,24 @@ class TestCase(unittest.TestCase):
         snapshots = [s for s in os.listdir(SNAPSHOTS_PATH) if s.startswith(name + "@")]
         self.assertEqual(len(snapshots), 1)
 
+    def test_a_line_the_scheduler_never_ran_starts_at_once(self):
+        """A weekly job used to wait six days after every restart
+
+        The scheduler wrote down exactly one day of lateness for a line it had
+        never seen, so a period longer than a day started late by the whole
+        difference, and nothing said so.
+        """
+        name = PREFIX_TEST_VOLUME + uuid.uuid4().hex
+        self.create_a_volume_with_a_file(name)
+        weekly = 7 * 24 * 60
+        with open(SCHEDULE, "w") as f:
+            f.write(f"{name},snapshot,{weekly},True\n")
+
+        runjobs(config=SCHEDULE, test=True, schedule_log={})
+
+        snapshots = os.listdir(SNAPSHOTS_PATH)
+        self.assertTrue(any(snap.startswith(name + "@") for snap in snapshots))
+
     def test_an_unknown_scheduled_action_is_reported(self):
         """A misspelled action in the schedule must be said out loud
 
@@ -1433,11 +1451,6 @@ class TestWhatIsDue(unittest.TestCase):
     def test_a_line_whose_timer_has_elapsed_is_due(self):
         now = datetime(2026, 8, 26, 12, 0)
         self.assertTrue(is_due(self.hourly(), now - timedelta(minutes=60), now))
-
-    def test_a_line_the_scheduler_has_never_seen_is_due(self):
-        """A daemon that just started writes down a day of lateness for it"""
-        now = datetime(2026, 8, 26, 12, 0)
-        self.assertTrue(is_due(self.hourly(), now - timedelta(days=1), now))
 
 
 class TestRunningAJob(unittest.TestCase):


### PR DESCRIPTION
Stacked on #99, itself on #98. Review those first.

The scheduler keeps in memory when each job last ran, and forgets it when it
stops. For a job it had never seen it pretended the last run was exactly one day
old, which is a number nobody chose. A job of a shorter period therefore started
immediately, a weekly one waited six days after every restart, a monthly one
twenty-nine. Nothing said so, and the only way to notice was the snapshot that
never came.

A line the scheduler has never run is now simply due. That is what the period of
a job means, and it is already what almost everyone sees, since the usual
periods are shorter than a day.

The test that stated the day of lateness on paper goes with it: the convention
it described no longer exists, and what replaces it is tested where it now
lives, on a weekly line that the scheduler runs at once. That test fails on #99.

What this does not do: make the memory of the last runs survive the daemon. A
restart still forgets everything and runs what is due, which is now everything.
Keeping those dates on disk needs a file, a format, and a decision about a date
that names a volume nobody kept, so it is a subject of its own.

64 tests pass, 4 skipped for want of SSH locally, `ruff` clean.
