### PR TITLE
Remember across a restart when each job last ran

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,18 @@ CHANGELOG
 3.13 (unreleased)
 *****************
 
+- The scheduler now remembers between two daemons when each job last ran. That
+  date lived in memory alone, and since a job the running daemon has never run
+  starts at once, every restart ran everything that was scheduled: a daily
+  purge on each reboot, a replication on each update of the plugin. It is now
+  written to ``/var/lib/buttervolume/lastruns.csv``, one line per volume and
+  action, next to the volumes rather than in the configuration. The restart
+  that brings this version still runs everything once, since there is no file
+  to read that day, and the ones after it pick the jobs up where they were
+  left. A job that leaves the schedule, or whose deprecated purge pattern is
+  converted, leaves its date behind: it costs a line, and that date is what
+  comes back if the job comes back.
+
 - A scheduled purge that failed is now tried again at the next scheduler
   round. Its date was written down whether it had worked or not, so a failure
 - A scheduled job the running daemon has never run now runs at once, instead

--- a/README.rst
+++ b/README.rst
@@ -291,6 +291,9 @@ You can configure the following variables:
     * ``SNAPSHOTS_PATH``: the path where the BTRFS snapshots are located
     * ``TEST_REMOTE_PATH``: the path during unit tests where the remote BTRFS snapshots are located
     * ``SCHEDULE``: the path of the scheduler configuration
+    * ``LAST_RUNS``: the path of the file where the scheduler writes down the date
+      of the last successful run of each scheduled job, so that a restart does not
+      run everything again
     * ``RUNPATH``: the path of the docker run directory (/run/docker)
     * ``SOCKET``: the path of the unix socket where buttervolume listens
     * ``TIMER``: the number of seconds between two runs of the scheduler jobs
@@ -319,6 +322,7 @@ If none of this is configured, the following default values are used:
     * ``SNAPSHOTS_PATH = /var/lib/buttervolume/snapshots/``
     * ``TEST_REMOTE_PATH = /var/lib/buttervolume/received/``
     * ``SCHEDULE = /etc/buttervolume/schedule.csv``
+    * ``LAST_RUNS = /var/lib/buttervolume/lastruns.csv``
     * ``RUNPATH = /run/docker``
     * ``SOCKET = $RUNPATH/plugins/btrfs.sock`` # only if run manually
     * ``TIMER = 60``

--- a/buttervolume/cli.py
+++ b/buttervolume/cli.py
@@ -12,9 +12,12 @@ a synchronization or a purge. Reading that file, and reading what each of its
 lines asks for, is ``schedule.py``'s business. What is left here is done in two
 steps that do not mix: ``is_due`` decides, from a line, a date and a clock,
 without touching anything; ``run_job`` does the work, one function per kind of
-job. ``schedule.csv`` is the only state the plugin keeps outside BTRFS; when
-a job last ran, and which replications are under way, live in memory alone and
-are forgotten when the daemon stops.
+job. The two files the plugin keeps outside BTRFS are both read and written in
+``schedule.py``: ``schedule.csv``, which says what to run, and ``lastruns.csv``,
+where the scheduler writes down the date of every job that succeeded. It reads
+that second file at each round rather than remembering anything, so a daemon
+that stops picks its jobs up where it left them. Only the replications under
+way live in memory, and a daemon that stops has none.
 """
 
 import argparse
@@ -43,6 +46,7 @@ from webtest import TestApp
 
 from buttervolume import ReplicationError, ValidationError
 from buttervolume.plugin import (
+    LAST_RUNS,
     LOGLEVEL,
     SCHEDULE,
     SNAPSHOTS_PATH,
@@ -59,8 +63,10 @@ from buttervolume.schedule import (
     Replicate,
     Snapshot,
     Synchronize,
+    read_last_runs,
     read_rows,
     read_schedule,
+    write_last_runs,
     write_schedule,
 )
 
@@ -354,7 +360,15 @@ def is_due(entry, last, now):
     Pure: a line, a date and a clock, nothing else. The clock is given rather
     than read here, so deciding what is due can be tested without a volume, a
     daemon or a filesystem.
+
+    A last run later than the clock is a date nobody can believe, and the job
+    is due. A host that boots with its clock ahead writes such a date, that
+    date now outlives the daemon, and without this the job would wait for a
+    day that never comes without a word. Running it says so and writes a date
+    that can be read.
     """
+    if last > now:
+        return True
     return now >= last + timedelta(minutes=int(entry.timer))
 
 
@@ -468,9 +482,14 @@ def run_synchronize(job: Synchronize, name, test=False):
     return True
 
 
-def runjobs(config=SCHEDULE, test=False, schedule_log=None):
-    if schedule_log is None:
-        schedule_log = {"snapshot": {}, "replicate": {}, "synchronize": {}}
+def runjobs(config=SCHEDULE, test=False, last_runs=LAST_RUNS):
+    """Run what the schedule owes, and write down the date of what succeeded.
+
+    The dates are read from their file at each round and written back to it as
+    soon as a job succeeds, so nothing of them is kept between two rounds: a
+    daemon that stops forgets nothing, and a job done at the beginning of a
+    round survives a machine that stops in the middle of it.
+    """
     log.info("New scheduler job at %s", datetime.now())
     # open the config and launch the tasks
     if not exists(config):
@@ -479,6 +498,7 @@ def runjobs(config=SCHEDULE, test=False, schedule_log=None):
         else:
             log.warning("No config file %s", config)
         return
+    dates = read_last_runs(last_runs) if exists(last_runs) else {}
     name = action = timer = ""
     # run each action in the schedule if time is elapsed since the last one
     for row in read_rows(config):
@@ -496,15 +516,16 @@ def runjobs(config=SCHEDULE, test=False, schedule_log=None):
                 log.warning("Skipping the unknown action %s of %s: %s", action, name, e)
                 continue
             now = datetime.now()
-            # a line this scheduler never ran is due: it is the first thing
-            # a freshly started daemon owes the volumes it was given
-            last = schedule_log.setdefault(action, {}).get(name)
+            # a line nobody has a date for is due: it is the first thing a
+            # daemon owes a volume it was just given
+            last = dates.setdefault(action, {}).get(name)
             if last is not None and not is_due(entry, last, now):
                 continue
             # the date a job answered for, so one that failed and can be
             # tried again comes back at the next round
             if run_job(job, name, test=test):
-                schedule_log[action][name] = now
+                dates[action][name] = now
+                write_last_runs(last_runs, dates)
         except CalledProcessError as e:
             log.error(
                 "Error processing scheduler action file %s "
@@ -529,17 +550,16 @@ def runjobs(config=SCHEDULE, test=False, schedule_log=None):
             )
 
 
-def scheduler(event, config=SCHEDULE, test=False, timer=TIMER):
+def scheduler(event, config=SCHEDULE, test=False, timer=TIMER, last_runs=LAST_RUNS):
     """Read the scheduler config and apply it, then run scheduler again."""
     log.info(f"Starting the scheduler thread. Next jobs will run in {timer} seconds")
-    schedule_log = {"snapshot": {}, "replicate": {}, "synchronize": {}}
     while not test and not event.is_set():
         if event.wait(timeout=float(timer)):
             log.info("Terminating the scheduler thread")
             return
         else:
             try:
-                runjobs(config, test, schedule_log=schedule_log)
+                runjobs(config, test, last_runs=last_runs)
             except Exception:
                 log.critical("An exception occured in the scheduling job")
                 log.critical(traceback.format_exc())

--- a/buttervolume/plugin.py
+++ b/buttervolume/plugin.py
@@ -64,6 +64,7 @@ SNAPSHOTS_PATH = getconfig(config, "SNAPSHOTS_PATH", "/var/lib/buttervolume/snap
 TEST_REMOTE_PATH = getconfig(config, "TEST_REMOTE_PATH", "/var/lib/buttervolume/received/")
 SCHEDULE = getconfig(config, "SCHEDULE", "/etc/buttervolume/schedule.csv")
 SCHEDULE_DISABLED = f"{SCHEDULE}.disabled"
+LAST_RUNS = getconfig(config, "LAST_RUNS", "/var/lib/buttervolume/lastruns.csv")
 # Support both old and new plugin names for backward compatibility
 DRIVERNAME = getconfig(config, "DRIVERNAME", "ccomb/buttervolume:latest")
 LEGACY_DRIVERNAME = "anybox/buttervolume:latest"

--- a/buttervolume/schedule.py
+++ b/buttervolume/schedule.py
@@ -15,25 +15,34 @@ an older version wrote it, and it must stay possible to list, to pause and to
 delete. So an ``Entry`` is the line as written, four strings, and reading the
 job out of it is a separate step nobody is forced to take.
 
-``read_schedule`` and ``write_schedule`` are the only place where the CSV
+``read_schedule`` and ``write_schedule`` are the only place where that CSV
 format is known. They are thin: turning a row into an ``Entry`` is pure, only
 the opening of the file is not. ``read_schedule`` says nothing about a file
 that is not there, because its callers answer that differently and it is their
 decision, not this module's. ``write_schedule`` replaces the file in one go,
-because it is the only state the plugin keeps outside BTRFS and a half-written
-schedule is a lost one.
+because a half-written schedule is a lost one.
+
+The scheduler keeps a second file here, and for the same reason: ``lastruns``
+holds the date each job last succeeded, one line per volume and action. It
+answers another question than the schedule, when a job ran rather than what it
+asks for, so it is another file, and the schedule stays the only one an
+administrator writes by hand.
 """
 
 import csv
+import logging
 import os
 import stat
 import tempfile
 from contextlib import suppress
 from dataclasses import dataclass
+from datetime import datetime
 
 from buttervolume import ValidationError
 from buttervolume.names import validate_hostname
 from buttervolume.purge import Pattern
+
+log = logging.getLogger()
 
 FIELDS = ["Name", "Action", "Timer", "Active"]
 
@@ -148,38 +157,38 @@ def read_schedule(path):
     return [Entry.parse(row) for row in read_rows(path)]
 
 
-def write_schedule(path, entries):
-    """Replace the file in one go, or leave it exactly as it was.
+def write_rows(path, rows):
+    """Replace this file in one go, or leave it exactly as it was.
 
     Writing in place would empty the file before knowing what goes back in it,
-    and an interruption there loses the whole schedule. So the lines are
+    and an interruption there loses everything it held. So the lines are
     written next to it and the file is renamed over the old one, which is
     atomic within a filesystem, hence the temporary file in the same directory.
 
     A rename replaces a name, where the previous write followed it: the file
-    written is the one the path really designates, so a schedule reached
-    through a symbolic link keeps being the file it points at.
+    written is the one the path really designates, so a file reached through a
+    symbolic link keeps being the file it points at.
 
     A machine that stops between the temporary file and the rename leaves that
-    temporary file behind. Nothing here removes it: it is named after the
-    schedule so that whoever finds it knows what it is, and deleting files
-    nobody asked to delete is how a schedule gets lost.
+    temporary file behind. Nothing here removes it: it is named after the file
+    it was about to become, so that whoever finds it knows what it is, and
+    deleting files nobody asked to delete is how a schedule gets lost.
     """
     path = os.path.realpath(path)
-    # the name says whose leftover it is, on the day a machine stops between
-    # this line and the rename below and leaves one behind
-    fd, tmp = tempfile.mkstemp(dir=os.path.dirname(path) or ".", prefix="schedule.")
+    fd, tmp = tempfile.mkstemp(
+        dir=os.path.dirname(path) or ".", prefix=f"{os.path.basename(path)}."
+    )
     try:
         with os.fdopen(fd, "w", newline="") as f:
-            csv.writer(f).writerows(entry.row for entry in entries)
+            csv.writer(f).writerows(rows)
             f.flush()
             # without this, a crash can bring the rename to the disk before
             # the lines it renames, which is the empty file we are avoiding
             os.fsync(f.fileno())
         # renaming gives a new file where writing in place kept the old one,
         # so the mode and the hands of the one being replaced are put back. A
-        # temporary file is readable by nobody else, and a schedule that names
-        # volumes and hosts has no reason to be born more open than that
+        # temporary file is readable by nobody else, and a file naming volumes
+        # and hosts has no reason to be born more open than that
         with suppress(FileNotFoundError):
             previous = os.stat(path)
             os.chmod(tmp, stat.S_IMODE(previous.st_mode))
@@ -188,3 +197,49 @@ def write_schedule(path, entries):
     except BaseException:
         os.unlink(tmp)
         raise
+
+
+def write_schedule(path, entries):
+    """Replace the schedule file, because a half-written schedule is a lost one."""
+    write_rows(path, [entry.row for entry in entries])
+
+
+def read_last_runs(path):
+    """When each job last succeeded: the date, by action and by volume.
+
+    A line nobody can read is skipped with a warning, and the job it named is
+    then a job we have no date for, which the scheduler runs at once. That is
+    one run too many, never one too few, and the lines around it keep their
+    date, the way the scheduler already reads schedule.csv line by line.
+
+    Raises if the file is not there, like ``read_schedule``: the first start
+    of a daemon and a file somebody deleted are the caller's business.
+    """
+    last_runs = {}
+    for row in read_rows(path):
+        try:
+            name, action, date = row
+            last_runs.setdefault(action, {})[name] = datetime.fromisoformat(date)
+        except ValueError as e:
+            log.warning("Skipping the unreadable line %s of %s: %s", row, path, e)
+    return last_runs
+
+
+def write_last_runs(path, last_runs):
+    """Write down when each job last succeeded.
+
+    A job that leaves the schedule leaves its date here, and so does one whose
+    action is rewritten, since the action as the schedule spells it is what
+    names it. Such a line costs a line, and it is that date which comes back
+    the day the job comes back, so nothing here goes looking for lines to
+    remove: what nobody asked to delete stays.
+    """
+    os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
+    write_rows(
+        path,
+        [
+            [name, action, date.isoformat()]
+            for action, names in last_runs.items()
+            for name, date in names.items()
+        ],
+    )

--- a/buttervolume/schedule.py
+++ b/buttervolume/schedule.py
@@ -219,10 +219,24 @@ def read_last_runs(path):
     for row in read_rows(path):
         try:
             name, action, date = row
-            last_runs.setdefault(action, {})[name] = datetime.fromisoformat(date)
+            last_runs.setdefault(action, {})[name] = read_date(date)
         except ValueError as e:
             log.warning("Skipping the unreadable line %s of %s: %s", row, path, e)
     return last_runs
+
+
+def read_date(text):
+    """A date this file holds, refused unless it can be compared to the clock.
+
+    ``datetime.now()`` has no time zone, and comparing it to a date that has
+    one raises. Such a date would therefore be read without a word and stop
+    its job at every round, which is the one thing this file must not do, so
+    it is refused here and the line goes the way of an unreadable one.
+    """
+    date = datetime.fromisoformat(text)
+    if date.tzinfo is not None:
+        raise ValueError(f"'{text}' carries a time zone, and the clock it is compared to has none")
+    return date
 
 
 def write_last_runs(path, last_runs):

--- a/test.py
+++ b/test.py
@@ -1679,6 +1679,14 @@ class TestLastRunsFile(unittest.TestCase):
 
         self.assertEqual(dates, {"replicate:node2": {"www": datetime(2026, 8, 26, 12, 0)}})
 
+    def test_a_date_carrying_a_time_zone_is_refused_like_an_unreadable_one(self):
+        """The clock it would be compared to has none, and comparing them raises"""
+        with open(self.path, "w", newline="") as f:
+            f.write("www,snapshot,2026-08-26T12:00:00+02:00\r\n")
+
+        with self.assertLogs(level=logging.WARNING):
+            self.assertEqual(read_last_runs(self.path), {})
+
     def test_a_file_that_is_not_there_says_so(self):
         """A first start and a file somebody deleted are the caller's business"""
         with self.assertRaises(FileNotFoundError):

--- a/test.py
+++ b/test.py
@@ -42,10 +42,19 @@ from buttervolume.plugin import (
     VOLUMES_PATH,
 )
 from buttervolume.purge import Pattern, compute_purges
-from buttervolume.schedule import Entry, Job, read_rows, read_schedule, write_schedule
+from buttervolume.schedule import (
+    Entry,
+    Job,
+    read_last_runs,
+    read_rows,
+    read_schedule,
+    write_last_runs,
+    write_schedule,
+)
 
 # check that the target dir is btrfs
 SCHEDULE = plugin.SCHEDULE = tempfile.mkstemp()[1]
+LAST_RUNS = tempfile.mkstemp()[1]
 PREFIX_TEST_VOLUME = "buttervolume-test-"
 
 
@@ -87,6 +96,8 @@ class TestCase(unittest.TestCase):
 
     def setUp(self):
         with open(SCHEDULE, "w") as f:
+            f.truncate()
+        with open(LAST_RUNS, "w") as f:
             f.truncate()
         self.app = TestApp(cli.app)
         # Check that the target dir is BTRFS - skip tests if not
@@ -182,14 +193,16 @@ class TestCase(unittest.TestCase):
         with patch("buttervolume.cli.send") as mock_send:
             mock_send.side_effect = slow_send
             # run the scheduler in a separate thread
-            t = threading.Thread(target=runjobs, args=(SCHEDULE, True))
+            t = threading.Thread(
+                target=runjobs, args=(SCHEDULE, True), kwargs={"last_runs": LAST_RUNS}
+            )
             t.start()
             # wait for the replication to start
             time.sleep(1)
             # check that the replication is in progress
             self.assertIn(name, cli.ReplicationInProgress)
             # run the scheduler again
-            runjobs(SCHEDULE, True)
+            runjobs(SCHEDULE, True, last_runs=LAST_RUNS)
             # check that the second replication was skipped
             mock_send.assert_called_once()
             # wait for the replication to finish
@@ -261,7 +274,7 @@ class TestCase(unittest.TestCase):
         )
         with patch("buttervolume.cli.send") as mock_send:
             mock_send.side_effect = Exception("replication failed")
-            runjobs(SCHEDULE, True)
+            runjobs(SCHEDULE, True, last_runs=LAST_RUNS)
         mock_send.assert_called_once()
         # the snapshot created for the failed replication was removed
         snapshots = [s for s in os.listdir(SNAPSHOTS_PATH) if s.startswith(name + "@")]
@@ -286,7 +299,7 @@ class TestCase(unittest.TestCase):
             # what the client answers when the endpoint fills the Err field
             mock_send.return_value = False
             with self.assertLogs(level=logging.INFO) as log_capture:
-                runjobs(SCHEDULE, True)
+                runjobs(SCHEDULE, True, last_runs=LAST_RUNS)
 
         self.assertFalse(any("Successfully replicated" in msg for msg in log_capture.output))
         self.assertTrue(any("Replication failed" in msg for msg in log_capture.output))
@@ -578,7 +591,7 @@ class TestCase(unittest.TestCase):
             lines = f.readlines()
             self.assertEqual(lines[1], f"{name2},snapshot,60,True\n")
         # run the scheduler jobs
-        runjobs(SCHEDULE, test=True)
+        runjobs(SCHEDULE, test=True, last_runs=LAST_RUNS)
         # check we have two snapshots
         self.assertEqual(
             2,
@@ -599,9 +612,9 @@ class TestCase(unittest.TestCase):
         schedule = json.loads(resp.body.decode())["Schedule"]
         self.assertEqual(len(schedule), 1)
         # simulate the last snapshot is 1 day in the past
-        schedule_log = {"snapshot": {name2: datetime.now() - timedelta(days=1)}}
+        write_last_runs(LAST_RUNS, {"snapshot": {name2: datetime.now() - timedelta(days=1)}})
         # run the scheduler jobs and check we only have one more snapshot
-        runjobs(SCHEDULE, test=True, schedule_log=schedule_log)
+        runjobs(SCHEDULE, test=True, last_runs=LAST_RUNS)
         self.assertEqual(
             3,
             len(
@@ -643,9 +656,11 @@ class TestCase(unittest.TestCase):
             json.dumps({"Name": "boo", "Action": "replicate:localhost", "Timer": 120}),
         )
         # simulate the last replicate is 1 day in the past
-        schedule_log = {"replicate:localhost": {name: datetime.now() - timedelta(days=1)}}
+        write_last_runs(
+            LAST_RUNS, {"replicate:localhost": {name: datetime.now() - timedelta(days=1)}}
+        )
         # run the scheduler jobs jobs and check we only have two more snapshots
-        runjobs(SCHEDULE, test=True, schedule_log=schedule_log)
+        runjobs(SCHEDULE, test=True, last_runs=LAST_RUNS)
         self.assertEqual(
             2,
             len(
@@ -978,9 +993,9 @@ class TestCase(unittest.TestCase):
             "/VolumeDriver.Schedule",
             json.dumps({"Name": name, "Action": "purge:2h", "Timer": 60}),
         )
-        schedule_log = {"purge:2h": {name: datetime.now() - timedelta(days=1)}}
+        write_last_runs(LAST_RUNS, {"purge:2h": {name: datetime.now() - timedelta(days=1)}})
         nb_snaps = len(os.listdir(SNAPSHOTS_PATH))
-        runjobs(config=SCHEDULE, test=True, schedule_log=schedule_log)
+        runjobs(config=SCHEDULE, test=True, last_runs=LAST_RUNS)
         self.assertEqual(len(os.listdir(SNAPSHOTS_PATH)), nb_snaps - 17)
         # unschedule
         self.app.post(
@@ -1000,13 +1015,13 @@ class TestCase(unittest.TestCase):
             "/VolumeDriver.Schedule",
             json.dumps({"Name": name, "Action": "purge:2h:2h", "Timer": 60}),
         )
-        schedule_log = {"purge:2h:2h": {name: datetime.now() - timedelta(days=1)}}
+        write_last_runs(LAST_RUNS, {"purge:2h:2h": {name: datetime.now() - timedelta(days=1)}})
         nb_snaps = len(os.listdir(SNAPSHOTS_PATH))
 
         # This should work (with warning) because scheduler uses backward compatibility
 
         with self.assertLogs(level=logging.WARNING) as log_capture:
-            runjobs(config=SCHEDULE, test=True, schedule_log=schedule_log)
+            runjobs(config=SCHEDULE, test=True, last_runs=LAST_RUNS)
 
         # Check that warning was logged
         self.assertTrue(
@@ -1035,13 +1050,14 @@ class TestCase(unittest.TestCase):
         self.create_a_volume_with_a_file(name)
         with open(SCHEDULE, "w") as f:
             f.write(f"{name},purge:2h,60,True\n")
-        schedule_log = {}
 
         with patch("buttervolume.cli.purge", return_value=False) as failing_purge:
-            runjobs(config=SCHEDULE, test=True, schedule_log=schedule_log)
-            runjobs(config=SCHEDULE, test=True, schedule_log=schedule_log)
+            runjobs(config=SCHEDULE, test=True, last_runs=LAST_RUNS)
+            runjobs(config=SCHEDULE, test=True, last_runs=LAST_RUNS)
 
         self.assertEqual(failing_purge.call_count, 2)
+        # nothing written down for a job that failed, not even across a restart
+        self.assertEqual(read_last_runs(LAST_RUNS), {})
 
     def test_a_synchronization_that_could_not_pull_waits_for_its_turn(self):
         """A purge that failed can be tried again for free, a pull cannot
@@ -1055,11 +1071,10 @@ class TestCase(unittest.TestCase):
         self.create_a_volume_with_a_file(name)
         with open(SCHEDULE, "w") as f:
             f.write(f"{name},synchronize:localhost,60,True\n")
-        schedule_log = {}
 
         with patch("buttervolume.cli.sync", return_value=False) as failing_sync:
-            runjobs(config=SCHEDULE, test=True, schedule_log=schedule_log)
-            runjobs(config=SCHEDULE, test=True, schedule_log=schedule_log)
+            runjobs(config=SCHEDULE, test=True, last_runs=LAST_RUNS)
+            runjobs(config=SCHEDULE, test=True, last_runs=LAST_RUNS)
 
         self.assertEqual(failing_sync.call_count, 1)
         snapshots = [s for s in os.listdir(SNAPSHOTS_PATH) if s.startswith(name + "@")]
@@ -1078,10 +1093,29 @@ class TestCase(unittest.TestCase):
         with open(SCHEDULE, "w") as f:
             f.write(f"{name},snapshot,{weekly},True\n")
 
-        runjobs(config=SCHEDULE, test=True, schedule_log={})
+        runjobs(config=SCHEDULE, test=True, last_runs=LAST_RUNS)
 
         snapshots = os.listdir(SNAPSHOTS_PATH)
         self.assertTrue(any(snap.startswith(name + "@") for snap in snapshots))
+
+    def test_the_scheduler_picks_its_jobs_up_where_it_left_them(self):
+        """The date of a job that ran used to die with the daemon
+
+        Since a line nobody has a date for starts at once, a restart ran
+        everything that was scheduled, whatever its period. The two rounds
+        below share nothing but the file, which is what a restart leaves.
+        """
+        name = PREFIX_TEST_VOLUME + uuid.uuid4().hex
+        self.create_a_volume_with_a_file(name)
+        with open(SCHEDULE, "w") as f:
+            f.write(f"{name},snapshot,60,True\n")
+
+        runjobs(config=SCHEDULE, test=True, last_runs=LAST_RUNS)
+        runjobs(config=SCHEDULE, test=True, last_runs=LAST_RUNS)
+
+        snapshots = [s for s in os.listdir(SNAPSHOTS_PATH) if s.startswith(name + "@")]
+        self.assertEqual(len(snapshots), 1)
+        self.assertIn(name, read_last_runs(LAST_RUNS)["snapshot"])
 
     def test_an_unknown_scheduled_action_is_reported(self):
         """A misspelled action in the schedule must be said out loud
@@ -1097,7 +1131,7 @@ class TestCase(unittest.TestCase):
         nb_snaps = len(os.listdir(SNAPSHOTS_PATH))
 
         with self.assertLogs(level=logging.WARNING) as log_capture:
-            runjobs(config=SCHEDULE, test=True)
+            runjobs(config=SCHEDULE, test=True, last_runs=LAST_RUNS)
 
         self.assertTrue(
             any(
@@ -1124,7 +1158,7 @@ class TestCase(unittest.TestCase):
             f.write(f"{healthy},snapshot,60,True\n")
 
         with self.assertLogs(level=logging.WARNING) as log_capture:
-            runjobs(config=SCHEDULE, test=True)
+            runjobs(config=SCHEDULE, test=True, last_runs=LAST_RUNS)
 
         self.assertTrue(any("Invalid schedule line" in msg for msg in log_capture.output))
         snapshots = os.listdir(SNAPSHOTS_PATH)
@@ -1186,7 +1220,7 @@ class TestCase(unittest.TestCase):
         nb_snaps = len(os.listdir(SNAPSHOTS_PATH))
 
         with self.assertLogs(level=logging.WARNING) as log_capture:
-            runjobs(config=SCHEDULE, test=True)
+            runjobs(config=SCHEDULE, test=True, last_runs=LAST_RUNS)
 
         self.assertTrue(any("replicate:backup_host" in msg for msg in log_capture.output))
         self.assertEqual(len(os.listdir(SNAPSHOTS_PATH)), nb_snaps)
@@ -1270,13 +1304,14 @@ class TestCase(unittest.TestCase):
             json.dumps({"Name": "boo", "Action": "synchronize:localhost", "Timer": 120}),
         )
         # simulate the last synchronize is 1 day in the past
-        schedule_log = {
-            "synchronize:localhost,wronghost.mlf": {name: datetime.now() - timedelta(days=1)}
-        }
+        write_last_runs(
+            LAST_RUNS,
+            {"synchronize:localhost,wronghost.mlf": {name: datetime.now() - timedelta(days=1)}},
+        )
         with TemporaryDirectory(path=remote_path) as remote_path:
             with open(join(remote_path, "foobar"), "w") as f:
                 f.write("test sync")
-            runjobs(SCHEDULE, test=True, schedule_log=schedule_log)
+            runjobs(SCHEDULE, test=True, last_runs=LAST_RUNS)
         # make sure a snapshot has occured before rsync
         snapshots = [s for s in os.listdir(SNAPSHOTS_PATH) if s.startswith(name)]
         self.assertEqual(1, len(snapshots))
@@ -1452,6 +1487,15 @@ class TestWhatIsDue(unittest.TestCase):
         now = datetime(2026, 8, 26, 12, 0)
         self.assertTrue(is_due(self.hourly(), now - timedelta(minutes=60), now))
 
+    def test_a_last_run_later_than_the_clock_is_not_believed(self):
+        """A host that booted with its clock ahead used to stop its own jobs
+
+        The date is written down and now outlives the daemon, so a job whose
+        last run sits in the future would wait for a day that never comes.
+        """
+        now = datetime(2026, 8, 26, 12, 0)
+        self.assertTrue(is_due(self.hourly(), now + timedelta(days=365), now))
+
 
 class TestRunningAJob(unittest.TestCase):
     """Which function runs which kind of job"""
@@ -1496,7 +1540,7 @@ class TestScheduleFile(unittest.TestCase):
             self.assertEqual(f.read(), "www,snapshot,60,True\r\nwww,purge:2h,120,False\r\n")
 
     def test_an_interrupted_write_leaves_the_previous_schedule_alone(self):
-        """This file is the only state outside BTRFS, and half of it is none of it"""
+        """A schedule is what a daemon owes its volumes, and half of it is none of it"""
         content = "www,snapshot,60,True\r\nwww,purge:2h,120,False\r\n"
         path = self.schedule_file(content)
 
@@ -1605,6 +1649,58 @@ class TestScheduleFile(unittest.TestCase):
                 f.read(),
                 "www,purge:2h,60,True\r\nwww,replicat:node2,60,True\r\nwww,snapshot,60,False\r\n",
             )
+
+
+class TestLastRunsFile(unittest.TestCase):
+    """The date of the last run of each job, kept between two daemons"""
+
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.path = os.path.join(self.tmpdir.name, "lastruns.csv")
+        self.addCleanup(self.tmpdir.cleanup)
+
+    def test_a_date_survives_being_written_and_read_back(self):
+        dates = {
+            "snapshot": {"www": datetime(2026, 8, 26, 12, 0)},
+            "purge:4h:1d:1w": {"www": datetime(2026, 8, 26, 2, 0, 7, 900011)},
+        }
+        write_last_runs(self.path, dates)
+        self.assertEqual(read_last_runs(self.path), dates)
+
+    def test_a_line_nobody_can_read_only_forgets_its_own_job(self):
+        """A job we have no date for runs at once: one run too many, never one too few"""
+        with open(self.path, "w", newline="") as f:
+            f.write(
+                "www,snapshot,not a date\r\nwww,purge:2h\r\nwww,replicate:node2,2026-08-26T12:00:00\r\n"
+            )
+
+        with self.assertLogs(level=logging.WARNING):
+            dates = read_last_runs(self.path)
+
+        self.assertEqual(dates, {"replicate:node2": {"www": datetime(2026, 8, 26, 12, 0)}})
+
+    def test_a_file_that_is_not_there_says_so(self):
+        """A first start and a file somebody deleted are the caller's business"""
+        with self.assertRaises(FileNotFoundError):
+            read_last_runs(self.path)
+
+    def test_the_directory_is_made_on_the_first_start(self):
+        path = os.path.join(self.tmpdir.name, "made", "lastruns.csv")
+        write_last_runs(path, {"snapshot": {"www": datetime(2026, 8, 26, 12, 0)}})
+        self.assertEqual(read_last_runs(path)["snapshot"]["www"], datetime(2026, 8, 26, 12, 0))
+
+    def test_a_leftover_temporary_file_says_which_file_it_comes_from(self):
+        """Two files are written here, and a temporary named after the other one lies"""
+
+        def rows():
+            yield ["www", "snapshot", "2026-08-26T12:00:00"]
+            raise OSError("No space left on device")
+
+        with patch("buttervolume.schedule.os.unlink"), self.assertRaises(OSError):
+            schedule.write_rows(self.path, rows())
+        left = os.listdir(self.tmpdir.name)
+        self.assertEqual(len(left), 1)
+        self.assertTrue(left[0].startswith("lastruns.csv."), left)
 
 
 class TemporaryDirectory(tempfile.TemporaryDirectory):

--- a/test_local.sh
+++ b/test_local.sh
@@ -18,7 +18,8 @@ cleanup_test_dir() {
     # simply refuse, and rm takes care of them below.
     sudo find "$LOCAL_TEST_DIR" -mindepth 1 -depth -type d \
         -exec btrfs subvolume delete {} \; > /dev/null 2>&1 || true
-    sudo rm -rf "$LOCAL_TEST_DIR"/volumes "$LOCAL_TEST_DIR"/snapshots "$LOCAL_TEST_DIR"/received
+    sudo rm -rf "$LOCAL_TEST_DIR"/volumes "$LOCAL_TEST_DIR"/snapshots \
+        "$LOCAL_TEST_DIR"/received "$LOCAL_TEST_DIR"/lastruns.csv
     # Left alone when it is a mount point, which is what the help text above
     # tells people to set up.
     rmdir "$LOCAL_TEST_DIR" 2> /dev/null || true
@@ -55,6 +56,7 @@ export BUTTERVOLUME_LOCAL_TEST=1
 export BUTTERVOLUME_VOLUMES_PATH="$LOCAL_TEST_DIR/volumes/"
 export BUTTERVOLUME_SNAPSHOTS_PATH="$LOCAL_TEST_DIR/snapshots/"
 export BUTTERVOLUME_TEST_REMOTE_PATH="$LOCAL_TEST_DIR/received/"
+export BUTTERVOLUME_LAST_RUNS="$LOCAL_TEST_DIR/lastruns.csv"
 
 # Setup virtual environment if it doesn't exist
 if [ ! -d ".venv" ]; then


### PR DESCRIPTION
The scheduler kept the date of every successful job in a dictionary that died
with the daemon. Since #100, a job it has never run starts at once, so a
restart ran everything the schedule held, whatever the period: a daily purge on
every reboot, a replication on every update of the plugin, and nothing said so.

That date now lives in a file, one line per volume and per action:

    doo.db,snapshot,2026-08-26T14:03:11.482145
    doo.db,replicate:node2,2026-08-26T13:12:44.001200
    doo.filestore,purge:4h:1d:1w,2026-08-26T02:00:07.900011

It is read at the beginning of each round and written back as soon as a job
succeeds, so the scheduler keeps nothing between two rounds. A machine that
stops in the middle of one no longer forgets the jobs already done, and a
failed job still writes nothing, which is what makes it come back a minute
later rather than a day later.

The file goes next to the volumes rather than in the configuration directory,
because it is a memory the daemon writes and not something an administrator
edits. Its path is the new `LAST_RUNS` setting, and `/var/lib/buttervolume` is
bind-mounted from the host, so it survives an update of the plugin image.

Two details that come with it:

- The schedule's atomic write is extracted as `write_rows` and reused. The
  temporary file left behind when a machine stops mid-write is now named after
  the file it was about to become, instead of always after the schedule, so
  whoever finds one still knows which of the two it belongs to.
- A last run later than the clock is no longer believed. A host that boots with
  its clock ahead writes such a date, and now that the date outlives the
  daemon, the job would have waited for a day that never comes.

Why a file rather than reading the dates off the snapshots: a `snapshot` job
and a `replicate` job leave their date in a name, but a `synchronize` leaves a
snapshot indistinguishable from a plain one, and a `purge` leaves nothing at
all. Two sources of truth for the same question would cost more than one small
file.

The restart that brings this version still runs everything once, since there is
no file to read that day. There is no migration, on purpose.

A job that leaves the schedule, or whose deprecated purge pattern is converted
by `scheduled --auto-convert-old-patterns`, leaves its date behind. It costs a
line, and that date is what comes back the day the job comes back.

Tested with `./test_local.sh`: 71 passed, 4 skipped (the SSH ones). The new
test runs the scheduler twice sharing only the file and expects a single
snapshot; making it forget the file between the two rounds brings back the two
snapshots of the current behaviour.
