### PR TITLE
Repair the changelog entry that stops mid-sentence

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,11 +16,9 @@ CHANGELOG
   converted, leaves its date behind: it costs a line, and that date is what
   comes back if the job comes back.
 
-- A scheduled purge that failed is now tried again at the next scheduler
-  round. Its date was written down whether it had worked or not, so a failure
 - A scheduled job the running daemon has never run now runs at once, instead
-  of starting a day late. The scheduler keeps in memory when each job last ran
-  and forgets it when it stops, and for a job it had never seen it pretended
+  of starting a day late. The scheduler kept in memory when each job last ran
+  and forgot it when it stopped, and for a job it had never seen it pretended
   the last run was exactly one day old. A job of a shorter period therefore
   started immediately, while a weekly one waited six days after every restart
   and a monthly one twenty-nine, without a word.


### PR DESCRIPTION
The 3.13 notes opened on two lines of a purge entry that ends on "so a failure" and goes no further. It is the beginning of the entry that appears whole a few lines below, left behind when that one was rewritten, so nothing is lost by removing it.

The entry about a job the daemon has never run is put in the past tense while we are here: it described a memory that died with the daemon, which #101 has since given a file, so the two entries of the same release contradicted each other.

Documentation only, no code touched.