### PR TITLE
Name the schedule line the scheduler could not read

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,13 @@ CHANGELOG
 3.13 (unreleased)
 *****************
 
+- The scheduler now names the schedule line it could not read, instead of the
+  one before it. The name, the action and the timer are only filled once a line
+  has been read whole, so a line nobody could read was reported with the fields
+  of the last one that went through, which is precisely the line that gave no
+  trouble. The message now carries the line at fault, column by column,
+  including the ``Active`` one those three fields left out.
+
 - The scheduler now remembers between two daemons when each job last ran. That
   date lived in memory alone, and since a job the running daemon has never run
   starts at once, every restart ran everything that was scheduled: a daily

--- a/buttervolume/cli.py
+++ b/buttervolume/cli.py
@@ -499,14 +499,13 @@ def runjobs(config=SCHEDULE, test=False, last_runs=LAST_RUNS):
             log.warning("No config file %s", config)
         return
     dates = read_last_runs(last_runs) if exists(last_runs) else {}
-    name = action = timer = ""
     # run each action in the schedule if time is elapsed since the last one
     for row in read_rows(config):
         try:
             # read here rather than in one go above: a line nobody can read
             # must not stop the lines that follow it
             entry = Entry.parse(row)
-            name, action, timer = entry.name, entry.action, entry.timer
+            name, action = entry.name, entry.action
             if not entry.enabled:
                 log.info(f"{action} of {name} is disabled")
                 continue
@@ -526,26 +525,23 @@ def runjobs(config=SCHEDULE, test=False, last_runs=LAST_RUNS):
             if run_job(job, name, test=test):
                 dates[action][name] = now
                 write_last_runs(last_runs, dates)
+        # the line at fault is the one being read, not the fields of the last
+        # one read whole: a line nobody could read never filled them
         except CalledProcessError as e:
             log.error(
-                "Error processing scheduler action file %s "
-                "name=%s, action=%s, timer=%s, "
+                "Error processing scheduler action file %s line=%s, "
                 "exception=%s, stdout=%s, stderr=%s",
                 config,
-                name,
-                action,
-                timer,
+                row,
                 str(e),
                 e.stdout,
                 e.stderr,
             )
         except Exception as e:
             log.error(
-                "Error processing scheduler action file %s name=%s, action=%s, timer=%s\n%s",
+                "Error processing scheduler action file %s line=%s\n%s",
                 config,
-                name,
-                action,
-                timer,
+                row,
                 str(e),
             )
 

--- a/test.py
+++ b/test.py
@@ -1166,6 +1166,29 @@ class TestCase(unittest.TestCase):
         self.assertTrue(any(s.startswith(healthy) for s in snapshots))
         self.assertFalse(any(s.startswith(mangled) for s in snapshots))
 
+    def test_the_scheduler_names_the_line_it_could_not_read(self):
+        """The line at fault, not the one before it
+
+        The fields of a line are only filled once it has been read whole, so a
+        message built from them names the last line that could be read, which
+        is precisely the one that gave no trouble.
+        """
+        healthy = PREFIX_TEST_VOLUME + uuid.uuid4().hex
+        mangled = PREFIX_TEST_VOLUME + uuid.uuid4().hex
+        self.create_a_volume_with_a_file(healthy)
+        with open(SCHEDULE, "w") as f:
+            f.write(f"{healthy},snapshot,60,True\n")
+            f.write(f"{mangled},snapshot,60,True,extra\n")
+
+        # the error alone: the healthy line announces itself at a lower level,
+        # and its name in the capture would say nothing about the error
+        with self.assertLogs(level=logging.ERROR) as log_capture:
+            runjobs(config=SCHEDULE, test=True, last_runs=LAST_RUNS)
+
+        error = "\n".join(log_capture.output)
+        self.assertIn(mangled, error)
+        self.assertNotIn(healthy, error)
+
     def test_a_schedule_nobody_could_run_is_refused(self):
         """The endpoint is where a schedule is written, so it is where it is judged"""
         name = PREFIX_TEST_VOLUME + uuid.uuid4().hex


### PR DESCRIPTION
A schedule line nobody could read was reported in the journal under the name, action and timer of the line *before* it, because those three fields are only filled once a line has been read whole and were kept from one line to the next.

Given this `schedule.csv`:

```
prod_db,snapshot,60,True
prod_files,snapshot,60,True,extra
```

the daemon accused `prod_db`, whose line had just run without trouble, and named the real culprit only inside the exception text on the following line. On the first line of a file the three fields were empty strings.

The two handlers of the loop now name `row`, the loop variable, which is always the line at fault, readable or not. The initialisation that carried the state across iterations is gone, and `timer` leaves the unpacking since only the replaced message used it.

The wording of that message changes, for anyone watching the journal: the three fields give way to the columns of the line at fault, including the `Active` one they left out.

A test writes a valid line followed by an unreadable one and checks that the error record names the second and not the first. It fails on `master`, which was verified by running it against the previous `cli.py`.

73 tests pass, 4 skipped for want of SSH locally, `ruff` clean.