### PR TITLE
Give the plugin's API its own client

### DIFF
--- a/buttervolume/api.py
+++ b/buttervolume/api.py
@@ -1,0 +1,184 @@
+"""How to reach the plugin: one function per endpoint, over the unix socket.
+
+Docker talks to the plugin through that socket, and so does everything else
+here: the command line and the scheduler are clients of the same API and read
+the same answers. This module is where that call is written, once, so nobody
+else has to know the socket path or how an answer is shaped.
+
+Each function takes what the endpoint needs and answers what it said, never an
+argparse namespace: printing belongs to ``cli.py`` and deciding to
+``scheduler.py``. A call that failed says so and has already been logged, so a
+caller can act on it without reading the exception.
+
+The ``test`` flag routes the same call through the Bottle application in this
+process instead of the socket, which is how the test suite exercises a whole
+command without a daemon. Whether it also travels in the payload is decided
+endpoint by endpoint, and copied here from what each one sent before: the send
+and the synchronization put it there and ``plugin.py`` reads it, to reach the
+next directory rather than another machine. The purge puts it there too and
+nobody reads it, which is left exactly as it was found rather than tidied up
+in a change that promises to alter nothing.
+"""
+
+import json
+import logging
+import os
+import urllib.parse
+
+import requests_unixsocket
+from bottle import app
+from requests.exceptions import ConnectionError
+from webtest import TestApp
+
+from buttervolume.plugin import USOCKET
+
+log = logging.getLogger()
+
+# The Bottle application the plugin has posted its routes on. Importing
+# plugin.py is what puts them there, hence the import above, which also gives
+# us the socket they answer on.
+app = app()
+
+
+class Session:
+    """wrapper for requests_unixsocket.Session"""
+
+    def __init__(self):
+        self.session = requests_unixsocket.Session()
+
+    def _log_connection_error(self):
+        """Log connection error with helpful guidance"""
+        log.error("Failed to connect to Buttervolume plugin.")
+
+        # Check if we're running in a container
+        if os.path.exists("/.dockerenv") or os.environ.get("BUTTERVOLUME_IN_CONTAINER"):
+            log.error("Running in container detected. To use buttervolume CLI in a container:")
+            log.error("1. Mount Docker socket: -v /var/run/docker.sock:/var/run/docker.sock")
+            log.error("2. Mount plugin sockets: -v /run/docker/plugins:/run/docker/plugins")
+            log.error("3. Or override socket path: -e BUTTERVOLUME_SOCKET=/path/to/btrfs.sock")
+        else:
+            log.error("You can start the plugin with: buttervolume run")
+            log.error("Or install the Docker plugin: docker plugin install ccomb/buttervolume")
+
+    def post(self, *a, **kw):
+        try:
+            return self.session.post(*a, **kw)
+        except ConnectionError:
+            self._log_connection_error()
+            return
+
+    def get(self, *a, **kw):
+        try:
+            return self.session.get(*a, **kw)
+        except ConnectionError:
+            self._log_connection_error()
+
+
+def get_from(resp, key):
+    """get specified key from plugin response output"""
+    if resp is None:
+        return False
+    try:  # bottle
+        content = resp.content
+    except Exception:  # TestApp
+        content = resp.body
+    if resp.status_code == 200:
+        error = json.loads(content.decode())["Err"]
+        if error:
+            log.error(error)
+            return False
+        return json.loads(content.decode()).get(key)
+    else:
+        log.error("%s: %s", resp.status_code, resp.reason)
+        return False
+
+
+def _url(urlpath):
+    return f"http+unix://{urllib.parse.quote_plus(USOCKET)}{urlpath}"
+
+
+def _post(urlpath, payload=None, test=False):
+    body = json.dumps(payload) if payload is not None else None
+    if test:
+        return TestApp(app).post(urlpath, body)
+    return Session().post(_url(urlpath), body)
+
+
+def _get(urlpath):
+    return Session().get(_url(urlpath))
+
+
+def snapshot(name, test=False):
+    """Snapshot a volume, and answer the name of the snapshot."""
+    return get_from(_post("/VolumeDriver.Snapshot", {"Name": name}, test), "Snapshot")
+
+
+def snapshots(name):
+    """The snapshots of a volume, or of every volume when the name is empty."""
+    return get_from(_get(f"/VolumeDriver.Snapshot.List/{name}"), "Snapshots")
+
+
+def restore(name, target=None):
+    """Restore a snapshot over its volume, and answer where the volume went."""
+    return get_from(
+        _post("/VolumeDriver.Snapshot.Restore", {"Name": name, "Target": target}),
+        "VolumeBackup",
+    )
+
+
+def clone(name, target=None):
+    """Clone a snapshot into a new volume, and answer its name."""
+    return get_from(_post("/VolumeDriver.Clone", {"Name": name, "Target": target}), "VolumeCloned")
+
+
+def send(snapshot, host, test=False):
+    """Send a snapshot to another host, and answer whether it went."""
+    payload = {"Name": snapshot, "Host": host}
+    if test:
+        # the plugin reads it to send the snapshot next door rather than to
+        # another machine
+        payload["Test"] = True
+    return get_from(_post("/VolumeDriver.Snapshot.Send", payload, test), "") is not False
+
+
+def sync(volumes, hosts, test=False):
+    """Pull these volumes back from these hosts, and answer whether it went."""
+    payload = {"Volumes": volumes, "Hosts": hosts}
+    if test:
+        payload["Test"] = True
+    return get_from(_post("/VolumeDriver.Volume.Sync", payload, test), "") is not False
+
+
+def remove(name, test=False):
+    """Delete a snapshot, and answer whether it was deleted."""
+    return get_from(_post("/VolumeDriver.Snapshot.Remove", {"Name": name}, test), "") is not False
+
+
+def purge(name, pattern, dryrun=False, test=False):
+    """Delete the snapshots this pattern does not keep, and answer whether it went."""
+    payload = {"Name": name, "Pattern": pattern, "Dryrun": dryrun}
+    if test:
+        payload["Test"] = True
+    return get_from(_post("/VolumeDriver.Snapshots.Purge", payload, test), "") is not False
+
+
+def schedule(name, action, timer):
+    """Add, pause, resume or remove a scheduled job."""
+    return get_from(
+        _post("/VolumeDriver.Schedule", {"Name": name, "Action": action, "Timer": timer}), ""
+    )
+
+
+def scheduled():
+    """Every line of the schedule, as the file holds it."""
+    return get_from(_get("/VolumeDriver.Schedule.List"), "Schedule")
+
+
+def schedule_pause():
+    """Stop running anything the schedule asks for."""
+    return get_from(_post("/VolumeDriver.Schedule.Pause"), "")
+
+
+def schedule_resume():
+    """Run again what the schedule asks for."""
+    return get_from(_post("/VolumeDriver.Schedule.Resume"), "")

--- a/buttervolume/cli.py
+++ b/buttervolume/cli.py
@@ -1,11 +1,16 @@
 """The command line, the scheduler thread, and the server Docker talks to.
 
-Most commands are argparse subcommands that post to the plugin over the unix
-socket, so the command line is a client of the same API as Docker and reads the
-same answers. Three do not: ``run`` starts waitress on that socket with the
-scheduler thread beside it, ``init`` builds a BTRFS filesystem before any
-daemon exists, and ``scheduled --auto-convert-old-patterns`` rewrites
-``schedule.csv`` in place.
+Most commands are argparse subcommands that unpack what the terminal gave
+them, hand it to ``api.py`` and print what comes back, so the command line is
+a client of the same API as Docker and reads the same answers. Three do not:
+``run`` starts waitress on that socket with the scheduler thread beside it,
+``init`` builds a BTRFS filesystem before any daemon exists, and ``scheduled
+--auto-convert-old-patterns`` rewrites ``schedule.csv`` in place.
+
+Nothing here knows how that call travels. Where the socket is, and what an
+answer is shaped like, is ``api.py``'s business, and the scheduler below calls
+it the same way the commands do, with the volume's name rather than the
+namespace argparse would have built.
 
 The scheduler runs what is due in ``schedule.csv``: a snapshot, a replication,
 a synchronization or a purge. Reading that file, and reading what each of its
@@ -21,7 +26,6 @@ way live in memory, and a daemon that stops has none.
 """
 
 import argparse
-import json
 import logging
 import os
 import shutil
@@ -30,7 +34,6 @@ import subprocess
 import sys
 import threading
 import traceback
-import urllib.parse
 from contextlib import suppress
 from dataclasses import replace
 from datetime import datetime, timedelta
@@ -38,13 +41,10 @@ from functools import singledispatch
 from os.path import exists
 from subprocess import CalledProcessError
 
-import requests_unixsocket
-from bottle import app
-from requests.exceptions import ConnectionError
 from waitress import serve
-from webtest import TestApp
 
-from buttervolume import ReplicationError, ValidationError
+from buttervolume import ReplicationError, ValidationError, api
+from buttervolume.api import app
 from buttervolume.plugin import (
     LAST_RUNS,
     LOGLEVEL,
@@ -52,7 +52,6 @@ from buttervolume.plugin import (
     SNAPSHOTS_PATH,
     SOCKET,
     TIMER,
-    USOCKET,
     VOLUMES_PATH,
 )
 from buttervolume.purge import Pattern
@@ -73,83 +72,20 @@ from buttervolume.schedule import (
 VERSION = "3.13.0"
 logging.basicConfig(level=LOGLEVEL)
 log = logging.getLogger()
-app = app()
 
 
 ReplicationInProgress = set()
 
 
-class Session:
-    """wrapper for requests_unixsocket.Session"""
-
-    def __init__(self):
-        self.session = requests_unixsocket.Session()
-
-    def _log_connection_error(self):
-        """Log connection error with helpful guidance"""
-        log.error("Failed to connect to Buttervolume plugin.")
-
-        # Check if we're running in a container
-        if os.path.exists("/.dockerenv") or os.environ.get("BUTTERVOLUME_IN_CONTAINER"):
-            log.error("Running in container detected. To use buttervolume CLI in a container:")
-            log.error("1. Mount Docker socket: -v /var/run/docker.sock:/var/run/docker.sock")
-            log.error("2. Mount plugin sockets: -v /run/docker/plugins:/run/docker/plugins")
-            log.error("3. Or override socket path: -e BUTTERVOLUME_SOCKET=/path/to/btrfs.sock")
-        else:
-            log.error("You can start the plugin with: buttervolume run")
-            log.error("Or install the Docker plugin: docker plugin install ccomb/buttervolume")
-
-    def post(self, *a, **kw):
-        try:
-            return self.session.post(*a, **kw)
-        except ConnectionError:
-            self._log_connection_error()
-            return
-
-    def get(self, *a, **kw):
-        try:
-            return self.session.get(*a, **kw)
-        except ConnectionError:
-            self._log_connection_error()
-
-
-def get_from(resp, key):
-    """get specified key from plugin response output"""
-    if resp is None:
-        return False
-    try:  # bottle
-        content = resp.content
-    except Exception:  # TestApp
-        content = resp.body
-    if resp.status_code == 200:
-        error = json.loads(content.decode())["Err"]
-        if error:
-            log.error(error)
-            return False
-        return json.loads(content.decode()).get(key)
-    else:
-        log.error("%s: %s", resp.status_code, resp.reason)
-        return False
-
-
 def snapshot(args, test=False):
-    urlpath = "/VolumeDriver.Snapshot"
-    param = json.dumps({"Name": args.name[0]})
-    if test:
-        resp = TestApp(app).post(urlpath, param)
-    else:
-        resp = Session().post(f"http+unix://{urllib.parse.quote_plus(USOCKET)}{urlpath}", param)
-    res = get_from(resp, "Snapshot")
+    res = api.snapshot(args.name[0], test=test)
     if res:
         print(res)
     return res
 
 
 def schedule(args):
-    urlpath = "/VolumeDriver.Schedule"
-    param = json.dumps({"Name": args.name[0], "Action": args.action[0], "Timer": args.timer[0]})
-    resp = Session().post(f"http+unix://{urllib.parse.quote_plus(USOCKET)}{urlpath}", param)
-    return get_from(resp, "")
+    return api.schedule(args.name[0], args.action[0], args.timer[0])
 
 
 def _auto_convert_old_patterns():
@@ -208,9 +144,7 @@ def scheduled(args):
         return _auto_convert_old_patterns()
 
     if args.action == "list":
-        urlpath = "/VolumeDriver.Schedule.List"
-        resp = Session().get(f"http+unix://{urllib.parse.quote_plus(USOCKET)}{urlpath}")
-        scheduled = get_from(resp, "Schedule")
+        scheduled = api.scheduled()
         if scheduled:
             formatted_jobs = []
             deprecated_patterns = []
@@ -245,113 +179,46 @@ def scheduled(args):
 
         return scheduled
     elif args.action == "pause":
-        resp = Session().post(
-            f"http+unix://{urllib.parse.quote_plus(USOCKET)}/VolumeDriver.Schedule.Pause",
-        )
-        return get_from(resp, "")
+        return api.schedule_pause()
     elif args.action == "resume":
-        resp = Session().post(
-            f"http+unix://{urllib.parse.quote_plus(USOCKET)}/VolumeDriver.Schedule.Resume",
-        )
-        return get_from(resp, "")
+        return api.schedule_resume()
 
 
 def snapshots(args):
-    resp = Session().get(
-        f"http+unix://{urllib.parse.quote_plus(USOCKET)}/VolumeDriver.Snapshot.List/{args.name}",
-    )
-    snapshots = get_from(resp, "Snapshots")
+    snapshots = api.snapshots(args.name)
     if snapshots:
         print("\n".join(snapshots))
     return snapshots
 
 
 def restore(args):
-    resp = Session().post(
-        f"http+unix://{urllib.parse.quote_plus(USOCKET)}/VolumeDriver.Snapshot.Restore",
-        json.dumps({"Name": args.name[0], "Target": args.target}),
-    )
-    res = get_from(resp, "VolumeBackup")
+    res = api.restore(args.name[0], args.target)
     if res:
         print(res)
     return res
 
 
 def clone(args):
-    resp = Session().post(
-        f"http+unix://{urllib.parse.quote_plus(USOCKET)}/VolumeDriver.Clone",
-        json.dumps({"Name": args.name[0], "Target": args.target}),
-    )
-    res = get_from(resp, "VolumeCloned")
+    res = api.clone(args.name[0], args.target)
     if res:
         print(res)
     return res
 
 
 def send(args, test=False):
-    urlpath = "/VolumeDriver.Snapshot.Send"
-    param = {"Name": args.snapshot[0], "Host": args.host[0]}
-    if test:
-        param["Test"] = True
-        resp = TestApp(app).post(urlpath, json.dumps(param))
-    else:
-        resp = Session().post(
-            f"http+unix://{urllib.parse.quote_plus(USOCKET)}{urlpath}",
-            json.dumps(param),
-        )
-    # the endpoint answers with an empty payload, so the only thing to report
-    # is whether the job happened: get_from already logged the error.
-    return get_from(resp, "") is not False
+    return api.send(args.snapshot[0], args.host[0], test=test)
 
 
 def sync(args, test=False):
-    urlpath = "/VolumeDriver.Volume.Sync"
-    param = {"Volumes": args.volumes, "Hosts": args.hosts}
-    if test:
-        param["Test"] = True
-        resp = TestApp(app).post(urlpath, json.dumps(param))
-    else:
-        resp = Session().post(
-            f"http+unix://{urllib.parse.quote_plus(USOCKET)}{urlpath}",
-            json.dumps(param),
-        )
-    # the endpoint answers with an empty payload, so the only thing to report
-    # is whether the job happened: get_from already logged the error.
-    return get_from(resp, "") is not False
+    return api.sync(args.volumes, args.hosts, test=test)
 
 
 def remove(args, test=False):
-    urlpath = "/VolumeDriver.Snapshot.Remove"
-    param = json.dumps({"Name": args.name[0]})
-    if test:
-        resp = TestApp(app).post(urlpath, param)
-    else:
-        resp = Session().post(f"http+unix://{urllib.parse.quote_plus(USOCKET)}{urlpath}", param)
-    # the endpoint answers with an empty payload, so the only thing to report
-    # is whether the deletion happened: get_from already logged the error.
-    return get_from(resp, "") is not False
+    return api.remove(args.name[0], test=test)
 
 
 def purge(args, test=False):
-    urlpath = "/VolumeDriver.Snapshots.Purge"
-    param = {"Name": args.name[0], "Pattern": args.pattern[0], "Dryrun": args.dryrun}
-    if test:
-        param["Test"] = True
-        resp = TestApp(app).post(urlpath, json.dumps(param))
-    else:
-        resp = Session().post(
-            f"http+unix://{urllib.parse.quote_plus(USOCKET)}{urlpath}",
-            json.dumps(param),
-        )
-    # the endpoint answers with an empty payload, so the only thing to report
-    # is whether the job happened: get_from already logged the error.
-    return get_from(resp, "") is not False
-
-
-class Arg:
-    def __init__(self, *_, **kw):
-        for k, v in kw.items():
-            setattr(self, k, v)
+    return api.purge(args.name[0], args.pattern[0], args.dryrun, test=test)
 
 
 def is_due(entry, last, now):
@@ -394,7 +261,7 @@ def run_job(job, name, test=False):
 @run_job.register
 def run_snapshot(job: Snapshot, name, test=False):
     log.info("Starting scheduled snapshot of %s", name)
-    snap = snapshot(Arg(name=[name]), test=test)
+    snap = api.snapshot(name, test=test)
     if not snap:
         log.info("Could not snapshot %s", name)
         return False
@@ -411,12 +278,12 @@ def run_replicate(job: Replicate, name, test=False):
     snap = None
     try:
         ReplicationInProgress.add(name)
-        snap = snapshot(Arg(name=[name]), test=test)
+        snap = api.snapshot(name, test=test)
         if not snap:
             log.info("Could not snapshot %s", name)
             return False
         log.info("Successfully snapshotted to %s", snap)
-        if not send(Arg(snapshot=[snap], host=[job.host]), test=test):
+        if not api.send(snap, job.host, test=test):
             # the same road as an exception: the error is already logged,
             # and the snapshot taken for this replication has no reason to stay
             raise ReplicationError(f"Could not send {snap} to {job.host}")
@@ -426,7 +293,7 @@ def run_replicate(job: Replicate, name, test=False):
         log.warning("Replication failed: %s", e)
         # remove snapshot that was created for the failed replication
         if snap:
-            if remove(Arg(name=[snap]), test=test):
+            if api.remove(snap, test=test):
                 log.info("Removed snapshot %s for failed replication", snap)
             else:
                 log.warning(
@@ -454,7 +321,7 @@ def run_purge(job: Purge, name, test=False):
             pattern.deprecated,
             pattern.text,
         )
-    if not purge(Arg(name=[name], pattern=[pattern.text], dryrun=False), test=test):
+    if not api.purge(name, pattern.text, dryrun=False, test=test):
         log.warning("Could not purge the snapshots of %s", name)
         return False
     log.info("Finished purging")
@@ -466,12 +333,15 @@ def run_synchronize(job: Synchronize, name, test=False):
     log.info("Starting scheduled synchronization of %s", name)
     hosts = list(job.hosts)
     # do a snapshot to save state before pulling data
-    snap = snapshot(Arg(name=[name]), test=test)
+    snap = api.snapshot(name, test=test)
     if not snap:
         log.info("Could not snapshot %s", name)
         return False
-    log.debug("Successfully snapshotted to %s", snap)
-    if sync(Arg(volumes=[name], hosts=hosts), test=test):
+    # said out loud, like the two other jobs that take one: this is the
+    # snapshot a pull stopped halfway is recovered from, and an administrator
+    # who has to go back to it needs to read its name somewhere
+    log.info("Successfully snapshotted to %s", snap)
+    if api.sync([name], hosts, test=test):
         log.debug("End of %s synchronization from %s", name, hosts)
     else:
         log.warning("Could not synchronize %s from %s", name, hosts)

--- a/test.py
+++ b/test.py
@@ -190,7 +190,7 @@ class TestCase(unittest.TestCase):
             time.sleep(2)
             return True
 
-        with patch("buttervolume.cli.send") as mock_send:
+        with patch("buttervolume.api.send") as mock_send:
             mock_send.side_effect = slow_send
             # run the scheduler in a separate thread
             t = threading.Thread(
@@ -272,7 +272,7 @@ class TestCase(unittest.TestCase):
             "/VolumeDriver.Schedule",
             json.dumps({"Name": name, "Action": "replicate:localhost", "Timer": 1}),
         )
-        with patch("buttervolume.cli.send") as mock_send:
+        with patch("buttervolume.api.send") as mock_send:
             mock_send.side_effect = Exception("replication failed")
             runjobs(SCHEDULE, True, last_runs=LAST_RUNS)
         mock_send.assert_called_once()
@@ -295,7 +295,7 @@ class TestCase(unittest.TestCase):
             "/VolumeDriver.Schedule",
             json.dumps({"Name": name, "Action": "replicate:localhost", "Timer": 1}),
         )
-        with patch("buttervolume.cli.send") as mock_send:
+        with patch("buttervolume.api.send") as mock_send:
             # what the client answers when the endpoint fills the Err field
             mock_send.return_value = False
             with self.assertLogs(level=logging.INFO) as log_capture:
@@ -1051,7 +1051,7 @@ class TestCase(unittest.TestCase):
         with open(SCHEDULE, "w") as f:
             f.write(f"{name},purge:2h,60,True\n")
 
-        with patch("buttervolume.cli.purge", return_value=False) as failing_purge:
+        with patch("buttervolume.api.purge", return_value=False) as failing_purge:
             runjobs(config=SCHEDULE, test=True, last_runs=LAST_RUNS)
             runjobs(config=SCHEDULE, test=True, last_runs=LAST_RUNS)
 
@@ -1072,7 +1072,7 @@ class TestCase(unittest.TestCase):
         with open(SCHEDULE, "w") as f:
             f.write(f"{name},synchronize:localhost,60,True\n")
 
-        with patch("buttervolume.cli.sync", return_value=False) as failing_sync:
+        with patch("buttervolume.api.sync", return_value=False) as failing_sync:
             runjobs(config=SCHEDULE, test=True, last_runs=LAST_RUNS)
             runjobs(config=SCHEDULE, test=True, last_runs=LAST_RUNS)
 


### PR DESCRIPTION
First of two: `cli.py` is 930 lines doing three jobs, and this one takes out the first.

Twelve times it built the same unix socket URL by hand, and five times it chose between that socket and the Bottle application running in this process. That now lives in `api.py`, written once, with one function per endpoint.

Those functions take what the endpoint needs, not the namespace argparse builds. That is what removes the `Arg` class:

```python
class Arg:
    def __init__(self, *_, **kw):
        for k, v in kw.items():
            setattr(self, k, v)
```

The scheduler wanted a snapshot; the only function that knew how to ask for one expected a command line; so the scheduler counterfeited one, down to the single-element lists `nargs=1` would have produced: `snapshot(Arg(name=[name]), test=test)`. It now calls `api.snapshot(name)` like anybody else.

Printing stays in `cli.py`, because a `print` speaks to a terminal and `api.py` has none. The commands are down to unpacking their arguments, calling `api` and printing what came back.

## The one thing that does change

Going through a terminal command, the scheduler printed the name of every snapshot it took on the daemon's standard output. That `print` is gone, which is the point of the change rather than an accident of it.

The name was already on the log line beside it for a scheduled snapshot and for a replication. For a synchronization it was only at `debug` level, and the default level is `INFO`, so it would have vanished: that line is raised to `info`. It names the snapshot the volume is recovered from when a pull stops halfway, which is not a detail.

Everything else is untouched: the return values (`main` exits 1 on a `False`, not on a `None`), every endpoint URL and payload key, and the `Test` flag, which still travels for exactly the endpoints that sent it before — the purge included, whose flag nobody reads and which is left as it was found rather than tidied up here.

This unblocks #105, which moves the scheduler out: it calls those five functions, and `cli.py` imports the scheduler to start its thread, which would have been a circular import.

73 tests pass, 4 skipped for want of SSH locally, `ruff` clean.