### PR TITLE
Say which Python version buttervolume needs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,13 @@ CHANGELOG
 3.13 (unreleased)
 *****************
 
+- Buttervolume now says it needs Python 3.11 or later. Nothing declared it, so
+  each version of ``uv`` invented its own floor and rewrote ``uv.lock`` on the
+  next command it was given, and an installation on an older Python failed on
+  the code instead of failing on the requirement. The plugin image has been
+  running 3.11 all along, which is the floor now written down; the classifiers
+  that still announced 3.8, 3.9 and 3.10 go with it.
+
 - The scheduler now names the schedule line it could not read, instead of the
   one before it. The name, the action and the timer are only filled once a line
   has been read whole, so a line nobody could read was reported with the fields

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ name = "buttervolume"
 version = "3.13.0"
 description = "BTRFS Volume plugin for Docker"
 readme = "README.rst"
+requires-python = ">=3.11"
 license = "MIT"
 authors = [
     {name = "Christophe Combelles", email = "ccomb@free.fr"},
@@ -17,9 +18,6 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Operating System :: POSIX :: Linux",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9", 
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Topic :: System :: Systems Administration",
 ]


### PR DESCRIPTION
`pyproject.toml` declared no `requires-python`, so each version of uv invented one: the lock file on master says 3.11, while uv 0.8.2 warns that it found none, defaults to 3.12 and rewrites `uv.lock`. The file came back modified after any command, in a direction that depended on who ran it last.

The floor is 3.11 because that is what the plugin image has always run: the Dockerfile builds on debian:12 and installs into `python3.11` site-packages. With the floor written down, `uv sync` leaves the lock file untouched here, and an installation on an older Python fails on the requirement instead of failing later on the code.

The classifiers announcing 3.8, 3.9 and 3.10 said the opposite, so they go.

Ruff still targets py38 on purpose: raising it to py311 turns on `B905` in four places and reformats `test.py`, which are code changes and belong to their own pull request.

`uv.lock` is not touched by this pull request. Tests: 73 passed, 4 skipped for want of SSH locally, ruff check and ruff format clean.